### PR TITLE
GET words routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ Navigate to [localhost:8080](http://localhost:8080/) to see the API
 
 ## Usage
 
-To search for a term, use the following route structure"
+### JSON Data
+
+To search for a term using the data in the **JSON dictionary**, use the following route structure:
 
 ```
 /api/v1/search/words?keyword=<keyword>
 ```
-
-The response will be a plain JSON object
 
 For example:
 
@@ -46,7 +46,23 @@ For example:
 http://localhost:8080/api/v1/search/words?keyword=agụū
 ```
 
-returns:
+### MongoDB Data
+
+**Note**: Make sure that you've populated your local MongoDB instance. Read through Locally Populating Dictionary Data to seed your MongoDB database.
+
+To search for a term using the data in **MongoDB**, use the following route structure:
+
+```
+/api/v1/test/words?keyword=<keyword>
+```
+
+For example:
+
+```
+http://localhost:8080/api/v1/test/words?keyword=agụū
+```
+
+The responses for both routes will be a plain JSON object similar to this:
 
 ```
 [

--- a/controllers/words.js
+++ b/controllers/words.js
@@ -12,7 +12,7 @@ export const createRegExp = (searchWord) => {
     const regexWordString = [...searchWord].reduce((regexWord, letter) => {
         return `${regexWord}${diacriticCodes[letter] || letter}`;
     }, '');
-    return new RegExp(`\\b${regexWordString}\\b`);
+    return new RegExp(`(\\B|\\b)${regexWordString}(\\B|\\b)`);
 };
 
 /* Gets words from JSON dictionary */
@@ -43,7 +43,8 @@ export const getWord = (keyword) => {
 /* Gets words from MongoDB */
 export const getWords = async (_, res) => {
     const { req: { query }} = res;
-    return query.keyword ? res.send(await getWord(query.keyword)) : res.send(Word.find({}));
+    const searchWord = removePrefix(query.keyword);
+    return query.keyword ? res.send(await getWord(searchWord)) : res.send(await Word.find({}));
 };
 
 /* Creates Word documents in MongoDB database */

--- a/dictionaries/seed.js
+++ b/dictionaries/seed.js
@@ -14,7 +14,7 @@ export const seedDatabase = async (_, res) => {
         res.status(400);
         return res.send('An error occurred during seeding');
     }
-}
+};
 
 const seed = () => {
     if (mongoose.connection.readyState !== 1) {
@@ -32,7 +32,7 @@ const seed = () => {
     } else {
         populate();
     }
-}
+};
 
 const populate = async () => {
     /* This route will populate a local MongoDB database */
@@ -42,7 +42,7 @@ const populate = async () => {
         const wordPromises = flatten(map(keys(dictionary), (key) => {
             const value = dictionary[key];
             return map(value, (term) => {
-                term.word = key
+                term.word = key;
                 createWord(term);
             });
         }));
@@ -60,4 +60,4 @@ const populate = async () => {
             });
         
     }
-}
+};

--- a/middleware/logger.js
+++ b/middleware/logger.js
@@ -1,0 +1,6 @@
+export default (req, _, next) => {
+    if (process.env.NODE_ENV === 'dev') {
+        console.log(req.query);
+    }
+    next();
+};

--- a/middleware/logger.js
+++ b/middleware/logger.js
@@ -1,4 +1,4 @@
-export default (req, _, next) => {
+export default (req, res, next) => {
     if (process.env.NODE_ENV === 'dev') {
         console.log(req.query);
     }

--- a/routers/index.js
+++ b/routers/index.js
@@ -1,0 +1,7 @@
+import router from './router';
+import testRouter from './testRouter';
+
+export {
+    router,
+    testRouter
+};

--- a/routers/router.js
+++ b/routers/router.js
@@ -1,0 +1,12 @@
+import express from 'express';
+import { getWordData } from '../controllers/words';
+
+const router = express.Router();
+
+router.get('/', (_, res) => {
+    res.send('Welcome to the Igbo English Dictionary API');
+});
+
+router.get('/words', getWordData);
+
+export default router;

--- a/routers/testRouter.js
+++ b/routers/testRouter.js
@@ -1,0 +1,10 @@
+import express from 'express';
+import { getWords } from '../controllers/words';
+import { seedDatabase } from '../dictionaries/seed';
+
+const testRouter = express.Router();
+
+testRouter.post('/populate', seedDatabase);
+testRouter.get('/words', getWords);
+
+export default testRouter;

--- a/server.js
+++ b/server.js
@@ -1,12 +1,11 @@
 import express from 'express';
 import mongoose from 'mongoose';
-import { getWordData, getWords } from './controllers/words';
-import { seedDatabase } from './dictionaries/seed';
+import { testRouter } from './routers';
+import logger from './middleware/logger';
 import { SERVER_PORT, MONGO_URI, TEST_MONGO_URI } from './config';
 
 const app = express();
 const router = express.Router();
-const testRouter = express.Router();
 
 mongoose.connect(process.env.NODE_ENV === 'test' ? TEST_MONGO_URI : MONGO_URI, {
     useNewUrlParser: true,
@@ -23,21 +22,7 @@ app.get('/', (_, res) => {
     res.send('Hello World!');
 });
 
-router.get('/', (_, res) => {
-    res.send('Welcome to the Igbo English Dictionary API');
-});
-
-router.get('/words', getWordData);
-
-testRouter.post('/populate', seedDatabase);
-testRouter.get('/words', getWords);
-
-app.use('*', (req, _, next) => {
-    if (process.env.NODE_ENV === 'dev') {
-        console.log(req.query);
-    }
-    next();
-});
+app.use('*', logger);
 
 /* Grabs data from JSON dictionary */
 app.use('/api/v1/search', router);

--- a/server.js
+++ b/server.js
@@ -1,11 +1,10 @@
 import express from 'express';
 import mongoose from 'mongoose';
-import { testRouter } from './routers';
+import { testRouter, router } from './routers';
 import logger from './middleware/logger';
 import { SERVER_PORT, MONGO_URI, TEST_MONGO_URI } from './config';
 
 const app = express();
-const router = express.Router();
 
 mongoose.connect(process.env.NODE_ENV === 'test' ? TEST_MONGO_URI : MONGO_URI, {
     useNewUrlParser: true,
@@ -29,10 +28,6 @@ app.use('/api/v1/search', router);
 
 /* Grabs data from MongoDB */
 app.use('/api/v1/test', testRouter);
-
-app.use((err, _, res) => {
-    res.send(err.message);
-});
 
 const server = app.listen(SERVER_PORT, () => {
     console.log(`🟢 Server started on port ${SERVER_PORT}`);

--- a/server.js
+++ b/server.js
@@ -27,7 +27,9 @@ app.use('*', logger);
 app.use('/api/v1/search', router);
 
 /* Grabs data from MongoDB */
-app.use('/api/v1/test', testRouter);
+if (process.env.NODE_ENV === 'dev' || process.env.NODE_ENV === 'test') {
+    app.use('/api/v1/test', testRouter);
+}
 
 const server = app.listen(SERVER_PORT, () => {
     console.log(`🟢 Server started on port ${SERVER_PORT}`);

--- a/shared/constants/diacriticCodes.js
+++ b/shared/constants/diacriticCodes.js
@@ -55,5 +55,5 @@ export default {
     'O': '[O\u00d2\u00d3\u014c\u1ecc]',
     'u': '[u\u00f9\u00fa\u016b\u1ee5]',
     'U': '[U\u00d9\u00da\u016a\u1ee4]',
-    ' ': '[\\s\u0027]',
+    ' ': '(\\B|\\b)[\\s\u0027](\\B|\\b)',
 };

--- a/tests/__mocks__/data.mock.json
+++ b/tests/__mocks__/data.mock.json
@@ -1,4 +1,456 @@
 {
+    "ànì ànà": [
+        {
+            "wordClass": "noun",
+            "definitions": [
+                "A. land; ground; soil"
+            ],
+            "examples": [],
+            "phrases": {
+                "ànì apìtì": {
+                    "definitions": [
+                        "swamp"
+                    ],
+                    "examples": []
+                },
+                "ànị èdò": {
+                    "definitions": [
+                        "Atanị area"
+                    ],
+                    "examples": []
+                },
+                "ànì ezè": {
+                    "definitions": [
+                        "kingdom"
+                    ],
+                    "examples": []
+                },
+                "ànì isī": {
+                    "definitions": [
+                        "skull of head"
+                    ],
+                    "examples": []
+                },
+                "ànị mmadù": {
+                    "definitions": [
+                        "A. foreign country; another person’s land",
+                        "B. land of the living (opposed to ànì mmụọ)"
+                    ],
+                    "examples": []
+                },
+                "ànì mmanụ anwū nà mmili ala efī": {
+                    "definitions": [
+                        "promised land (land of milk and honey)"
+                    ],
+                    "examples": []
+                },
+                "ànị mmānya": {
+                    "definitions": [
+                        "dregs of wine"
+                    ],
+                    "examples": []
+                },
+                "ànì mmarùbe": {
+                    "definitions": [
+                        "earthquake"
+                    ],
+                    "examples": []
+                },
+                "ànị mmụọ": {
+                    "definitions": [
+                        "land of the dead (opposed to ànị mmadù, land of the living) (Christian usage) hell; Hades"
+                    ],
+                    "examples": [
+                        "Ọ līdàlù n’ànị mmụọ He descended into hell"
+                    ]
+                },
+                "ànì obì": {
+                    "definitions": [
+                        "place of abode; settlement"
+                    ],
+                    "examples": []
+                },
+                "ànì ogwē akā": {
+                    "definitions": [
+                        "forearm"
+                    ],
+                    "examples": []
+                },
+                "ànì okwū": {
+                    "definitions": [
+                        "most important part of the story"
+                    ],
+                    "examples": []
+                },
+                "ànì olū": {
+                    "definitions": [
+                        "land overflowed in wet season"
+                    ],
+                    "examples": []
+                },
+                "ànì ọcha": {
+                    "definitions": [
+                        "A. dry land, not overflowed in wet season",
+                        "B. Igbo land"
+                    ],
+                    "examples": []
+                },
+                "ànị ōma jìjìjì": {
+                    "definitions": [
+                        "earthquake"
+                    ],
+                    "examples": []
+                },
+                "ànì ọnà ọcha nà ọnā èdò": {
+                    "definitions": [
+                        "land of gold and silver"
+                    ],
+                    "examples": []
+                },
+                "ànì ụkwū": {
+                    "definitions": [
+                        "heel of the foot"
+                    ],
+                    "examples": []
+                },
+                "ànì ụlō": {
+                    "definitions": [
+                        "clay soil"
+                    ],
+                    "examples": []
+                },
+                "akwụ ànì": {
+                    "definitions": [
+                        "white ant (the type that lives in the ground) (literally palmnut of the ground)"
+                    ],
+                    "examples": []
+                },
+                "àrụ ànì": {
+                    "definitions": [
+                        "quietness"
+                    ],
+                    "examples": []
+                },
+                "awa ànì": {
+                    "definitions": [
+                        "division, plot, of land"
+                    ],
+                    "examples": []
+                },
+                "-bọ ànì": {
+                    "definitions": [
+                        "scratch, paw the ground (of fowls, dogs)"
+                    ],
+                    "examples": []
+                },
+                "-dị ànì": {
+                    "definitions": [
+                        "be low"
+                    ],
+                    "examples": [
+                        "Oche à dì ànì This chair is low"
+                    ]
+                },
+                "-do ànì": {
+                    "definitions": [
+                        "settle a country; establish peace"
+                    ],
+                    "examples": []
+                },
+                "-dolu ànì": {
+                    "definitions": [
+                        "put down"
+                    ],
+                    "examples": []
+                },
+                "-dolu àrụ ànì": {
+                    "definitions": [
+                        "take things easy"
+                    ],
+                    "examples": []
+                },
+                "enu ànì": {
+                    "definitions": [
+                        "dry land (as opposed to water); high land between Asaba and Agbor"
+                    ],
+                    "examples": []
+                },
+                "enū nà ànì": {
+                    "definitions": [
+                        "‘up and down’; blouse and wrapper made of same material"
+                    ],
+                    "examples": []
+                },
+                "-fè ànì": {
+                    "definitions": [
+                        "prepare land for planting by propitiating the gods concerned"
+                    ],
+                    "examples": []
+                },
+                "-gbabo ànì": {
+                    "definitions": [
+                        "kick up the ground"
+                    ],
+                    "examples": []
+                },
+                "-gbakìlì ànì": {
+                    "definitions": [
+                        "run hither and thither; make fuss; be dilatory, going hither and thither without anything being seen done by the person; dilly- dally"
+                    ],
+                    "examples": []
+                },
+                "-kpa okē ànì": {
+                    "definitions": [
+                        "make boundary between lands"
+                    ],
+                    "examples": []
+                },
+                "-kpọbo ànì": {
+                    "definitions": [
+                        "level ground; break ground for planting"
+                    ],
+                    "examples": []
+                },
+                "-kpọ isi ànì": {
+                    "definitions": [
+                        "prostrate; cringe; worship; beg"
+                    ],
+                    "examples": []
+                },
+                "-kpọ ànì": {
+                    "definitions": [
+                        "clear ground by burning"
+                    ],
+                    "examples": []
+                },
+                "-lu ànì": {
+                    "definitions": [
+                        "arrive at a settlement or conclusion"
+                    ],
+                    "examples": []
+                },
+                "-lụ ànì": {
+                    "definitions": [
+                        "wreak havoc; commit treachery, abominably wicked or cruel act"
+                    ],
+                    "examples": []
+                },
+                "-lụcha ànì": {
+                    "definitions": [
+                        "cultivate land; clear weeds"
+                    ],
+                    "examples": []
+                },
+                "ǹgwu ànì": {
+                    "definitions": [
+                        "tool for digging; digger"
+                    ],
+                    "examples": []
+                },
+                "ǹtọ ànì": {
+                    "definitions": [
+                        "foundation; origin"
+                    ],
+                    "examples": []
+                },
+                "òbì n’ànà alā ajā": {
+                    "definitions": [
+                        "one who lives underground but does not absorb earth (i.e. masquerade)"
+                    ],
+                    "examples": []
+                },
+                "onu ànì": {
+                    "definitions": [
+                        "low tone"
+                    ],
+                    "examples": []
+                },
+                "Ọ nà-èkwu n’onu ànì": {
+                    "definitions": [
+                        "He is speaking in low tones"
+                    ],
+                    "examples": []
+                },
+                "onye ànì": {
+                    "definitions": [
+                        "fellow countryman"
+                    ],
+                    "examples": []
+                },
+                "onye ànị mmadù": {
+                    "definitions": [
+                        "foreigner; stranger"
+                    ],
+                    "examples": []
+                },
+                "ọkpụ ànì": {
+                    "definitions": [
+                        "ancient; long-established"
+                    ],
+                    "examples": []
+                },
+                "òkpụkpa ànì": {
+                    "definitions": [
+                        "making of boundary"
+                    ],
+                    "examples": []
+                },
+                "ọmụ ànì": {
+                    "definitions": [
+                        "bottom"
+                    ],
+                    "examples": []
+                },
+                "ọrụ ànì": {
+                    "definitions": [
+                        "dregs (of wine)"
+                    ],
+                    "examples": []
+                },
+                "òsụsụ ànì": {
+                    "definitions": [
+                        "cutting, clearing of bush preparatory to farming"
+                    ],
+                    "examples": []
+                },
+                "-pu n’ànì": {
+                    "definitions": [
+                        "be native or home-born, indigenous (literally grow, sprout in the soil)"
+                    ],
+                    "examples": []
+                },
+                "-rulu ànì": {
+                    "definitions": [
+                        "stoop down"
+                    ],
+                    "examples": []
+                },
+                "-runata ànì": {
+                    "definitions": [
+                        "stoop down a bit"
+                    ],
+                    "examples": []
+                },
+                "-sekpùlu ànì": {
+                    "definitions": [
+                        "worship; bow, kneel down; give honour to"
+                    ],
+                    "examples": []
+                },
+                "-sù isi n’ànì": {
+                    "definitions": [
+                        "fall headlong; throw oneself headlong"
+                    ],
+                    "examples": []
+                },
+                "-sù n’ànì": {
+                    "definitions": [
+                        "thump on the ground; set down heavily"
+                    ],
+                    "examples": []
+                },
+                "-tò anya n’ànì": {
+                    "definitions": [
+                        "be observant, watchful, careful; take notice of; watch (literally lay the eye to the ground)"
+                    ],
+                    "examples": []
+                },
+                "-tò ntì n’ànì": {
+                    "definitions": [
+                        "hearken; pay attention (literally lay the ear to the ground)"
+                    ],
+                    "examples": []
+                },
+                "-tò ǹtọ ànì": {
+                    "definitions": [
+                        "lay foundation"
+                    ],
+                    "examples": []
+                },
+                "ụgbọ ànì": {
+                    "definitions": [
+                        "lorry; car"
+                    ],
+                    "examples": []
+                },
+                "ùsọ ànì": {
+                    "definitions": [
+                        "A. boundary (of farmland)",
+                        "B. bank of river"
+                    ],
+                    "examples": []
+                },
+                "-wa ànì": {
+                    "definitions": [
+                        "break up land by digging; divide land for planting; dig ground"
+                    ],
+                    "examples": []
+                },
+                "-wedàta ànì": {
+                    "definitions": [
+                        "bring down; humble; humiliate"
+                    ],
+                    "examples": [
+                        "B. Ànì, Ànà the Earth Spirit, regarded as the mother of all men, the queen of the underworld, and the custodian of public morality"
+                    ]
+                },
+                "Ajaànà": {
+                    "definitions": [
+                        "aspect of the earth related to death rites"
+                    ],
+                    "examples": []
+                },
+                "Ànìegbòka": {
+                    "definitions": [
+                        "person’s name"
+                    ],
+                    "examples": []
+                },
+                "Ànìèmeka": {
+                    "definitions": [
+                        "person’s name (literally The land has done very well)"
+                    ],
+                    "examples": []
+                },
+                "Ànị ēzi": {
+                    "definitions": [
+                        "the shrine of Ànì owned by the head of a compound, kept in front of his house"
+                    ],
+                    "examples": []
+                },
+                "Ànị Ònìchà": {
+                    "definitions": [
+                        "secret place worshipped by Onitsha people"
+                    ],
+                    "examples": []
+                },
+                "alụlụ Ànì": {
+                    "definitions": [
+                        "injustice; maltreatment; wickedness"
+                    ],
+                    "examples": []
+                },
+                "ezē Ànì": {
+                    "definitions": [
+                        "life-size status of carved wood, representing Ànì"
+                    ],
+                    "examples": []
+                },
+                "nsọ Ànì": {
+                    "definitions": [
+                        "abomination"
+                    ],
+                    "examples": []
+                },
+                "-rù Ànì": {
+                    "definitions": [
+                        "sacrifice to Ànì"
+                    ],
+                    "examples": []
+                }
+            }
+        }
+    ],
     "ama": [
         {
             "wordClass": "n.",

--- a/tests/parse.test.js
+++ b/tests/parse.test.js
@@ -29,10 +29,10 @@ describe('Parse', () => {
             searchTerm(keyword)
             .end((_, res) => {
                 expect(res.status).to.equal(200);
-                expect(keys(res.body).length).to.be.greaterThan(2);
+                expect(keys(res.body)).to.have.lengthOf.at.least(2);
                 expect(res.body[keyword]).to.be.an('array');
-                expect(res.body[keyword][0].definitions.length).to.be.at.least(1);
-                expect(res.body[keyword][0].examples.length).to.equal(1);
+                expect(res.body[keyword][0].definitions).to.have.lengthOf.at.least(1);
+                expect(res.body[keyword][0].examples).to.have.lengthOf(1);
                 done();
             });
         });
@@ -43,7 +43,7 @@ describe('Parse', () => {
             .end((_, res) => {
                 expect(res.status).to.equal(200);
                 expect(res.body['-zu-zò']).to.exist;
-                expect(keys(res.body['-zu-zò'][0].phrases).length).to.be.at.least(1);
+                expect(keys(res.body['-zu-zò'][0].phrases)).to.have.lengthOf.at.least(1);
                 done();
             });
         });
@@ -55,7 +55,7 @@ describe('Parse', () => {
             .end((_, { body: { chi: res }}) => {
                 const termPhraseDefinitions = res[0].phrases[phraseKeyword].definitions;
                 const expectedDefinition = `a goat given to one's mother for her personal chi, which must never be killed`;
-                expect(termPhraseDefinitions.length).to.be.at.least(1);
+                expect(termPhraseDefinitions).to.have.lengthOf.at.least(1);
                 expect(termPhraseDefinitions[0]).to.equal(expectedDefinition);
                 done();
             });
@@ -66,7 +66,7 @@ describe('Parse', () => {
             searchTerm(keyword)
             .end((_, { body: { chi: res }}) => {
                 const termDefinitions = res[0].definitions;
-                expect(termDefinitions.length).to.be.at.least(2);
+                expect(termDefinitions).to.have.lengthOf.at.least(2);
                 done();
             });
         });
@@ -78,12 +78,12 @@ describe('Parse', () => {
                 expect(res.status).to.equal(200);
                 expect(res.body).to.be.an('object');
                 expect(res.body[keyword]).to.be.an('array');
-                expect(keys(res.body[keyword][0].phrases).length).to.be.at.least(5);
+                expect(keys(res.body[keyword][0].phrases)).to.have.lengthOf.at.least(5);
                 done();
             });
         });
 
-        it.only('should include the entire phrases', (done) => {
+        it('should include the entire phrases', (done) => {
             const keywords = ['ànì ànà', '-bè'];
             const expectedPhrases = ['ànì mmanụ anwū nà mmili ala efī', 'Bèelụchī, Bèelụchukwu'];
             Promise.all(map(['ànì ànà', 'be'], (keyword, index) => {
@@ -116,11 +116,18 @@ describe('Parse', () => {
                 expect(keys(res)[0]).to.equal("n'oge");
                 done();
             });
-    
-            it('should return term with apostrophe by using apostrophe', (done) => {
-                const res = searchMockedTerm("n'oge");
+
+            it('should return term with space with non word characters', (done) => {
+                const res = searchMockedTerm('n oge');
                 expect(res).to.be.an('object');
                 expect(keys(res)[0]).to.equal("n'oge");
+                done();
+            });
+    
+            it('should return term with apostrophe by using apostrophe', (done) => {
+                const res = searchMockedTerm('ànì ànà');
+                expect(res).to.be.an('object');
+                expect(keys(res)[0]).to.equal('ànì ànà');
                 done();
             });
 
@@ -130,7 +137,7 @@ describe('Parse', () => {
                 searchTerm(keyword)
                 .end((_, res) => {
                     expect(res.status).to.equal(200);
-                    expect(keys(res.body).length).to.equal(3);
+                    expect(keys(res.body)).to.have.lengthOf(3);
                     expect(isEqual(keys(res.body), resKeys)).is.true;
                     done();
                 });

--- a/tests/shared/commands.js
+++ b/tests/shared/commands.js
@@ -9,13 +9,14 @@ import mockedData from '../__mocks__/data.mock.json';
 export const populateAPI = () => {
     return chai.request(server)
         .post(`${API_ROUTE}/populate`);
-}
+};
 
 /* Uses the data in MongoDB */
-export const searchAPITerm = () => {
+export const searchAPITerm = (term) => {
     return chai.request(server)
-        .get(API_ROUTE);
-}
+        .get(`${API_ROUTE}/words`)
+        .query({ keyword: term });
+};
 
 /* Uses data in JSON */
 export const searchTerm = (term) => {


### PR DESCRIPTION
Now there are two different routes:

```
api/v1/search/words // JSON data
api/v1/test/words // MongoDB data
```

After populating the database, developers can use `api/v1/test/words` to search for words.

Closes #47 