### PR TITLE
Switch Express Routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,11 @@ Navigate to [localhost:8080](http://localhost:8080/) to see the API
 
 ## Usage
 
-### JSON Data
+### MongoDB Data
 
-To search for a term using the data in the **JSON dictionary**, use the following route structure:
+The database will initially be empty, meaning that no words will be returned from the API. To populate your local MongoDB database, read through [Locally Populating Dictionary Data](#populating-data)
+
+Once you've populated your data, use the follow route structure to get word information:
 
 ```
 /api/v1/search/words?keyword=<keyword>
@@ -54,11 +56,9 @@ For example:
 http://localhost:8080/api/v1/search/words?keyword=agụū
 ```
 
-### MongoDB Data
+### JSON Data
 
-**Note**: Make sure that you've populated your local MongoDB instance. Read through [Locally Populating Dictionary Data](#populating-data) to seed your MongoDB database.
-
-To search for a term using the data in **MongoDB**, use the following route structure:
+If you don't want the API to serve the word data from MongoDB, you can use the follow route to get the words that are stored in the **JSON dictionary**:
 
 ```
 /api/v1/test/words?keyword=<keyword>
@@ -106,25 +106,25 @@ The responses for both routes will be a plain JSON object similar to this:
 
 <h2 id="populating-data">Locally Populating Dictionary Data</h2>
 
-This project uses [MongoDB](https://docs.mongodb.com/drivers/node/) to store local data.
+This project requires the use of [MongoDB](http://docs.mongodb.com/) to locally store data. If you don't have MongoDB installed you can ge it [here](https://docs.mongodb.com/manual/administration/install-community/).
 
 To populate the database complete the following steps:
 
 ### 1. Build a Dictionary
 
-[`dictionary.html`](./dictionaries/html/dictionary.html) is an HTML representation of the Columbia PDF.
+[`dictionary.html`](./dictionaries/html/dictionary.html) is an HTML representation of the Columbia PDF that contains all the words and their information.
 
-The following command parses it and builds a number of JSON dictionaries:
+The following command parses the `html` file and builds a number JSON files:
 
 ```
 yarn build
 ```
 
-Here's an example JSON dictionary object: [ig-en/ig-en_expanded.json](./dictionaries/ig-en/ig-en_expanded.json)
+Here's an example JSON dictionary file: [ig-en/ig-en_expanded.json](./dictionaries/ig-en/ig-en_expanded.json)
 
 ### 2. Populate the MongoDB Database
 
-Now that we have the data, we need to use that data to populate, or seed, the database:
+Now that the data has been parsed, it needs to be used to populate, or seed, the MongoDB database.
 
 Start the development server:
 
@@ -144,11 +144,11 @@ For example:
 http://localhost:8080/api/v1/test/populate // POST
 ```
 
-If you see the `✅ Seeding successful.` message in your terminal, then you have successfully populated your database
+After about 20 seconds, if you see the `✅ Seeding successful.` message in your terminal, then you have successfully populated your database!
 
 ### 3. See Data in Database (Optional)
 
-Now that the data is living in a local instance of your database, you can see it either using the `mongo` command line tool, or through [MongoDB Compass](https://www.mongodb.com/try/download/compass)
+Now that the data is living in a local database, you can see it either using the `mongo` command line tool, or through [MongoDB Compass](https://www.mongodb.com/try/download/compass)
 
 ## Testing
 

--- a/routers/router.js
+++ b/routers/router.js
@@ -1,12 +1,8 @@
 import express from 'express';
-import { getWordData } from '../controllers/words';
+import { getWords } from '../controllers/words';
 
 const router = express.Router();
 
-router.get('/', (_, res) => {
-    res.send('Welcome to the Igbo English Dictionary API');
-});
-
-router.get('/words', getWordData);
+router.get('/words', getWords);
 
 export default router;

--- a/routers/testRouter.js
+++ b/routers/testRouter.js
@@ -1,10 +1,14 @@
 import express from 'express';
-import { getWords } from '../controllers/words';
+import { getWordData } from '../controllers/words';
 import { seedDatabase } from '../dictionaries/seed';
 
 const testRouter = express.Router();
 
+testRouter.get('/', (_, res) => {
+    res.send('Welcome to the Igbo English Dictionary API');
+});
+
 testRouter.post('/populate', seedDatabase);
-testRouter.get('/words', getWords);
+testRouter.get('/words', getWordData);
 
 export default testRouter;

--- a/server.js
+++ b/server.js
@@ -23,10 +23,10 @@ app.get('/', (_, res) => {
 
 app.use('*', logger);
 
-/* Grabs data from JSON dictionary */
+/* Grabs data from MongoDB */
 app.use('/api/v1/search', router);
 
-/* Grabs data from MongoDB */
+/* Grabs data from JSON dictionary */
 if (process.env.NODE_ENV === 'dev' || process.env.NODE_ENV === 'test') {
     app.use('/api/v1/test', testRouter);
 }

--- a/tests/shared/commands.js
+++ b/tests/shared/commands.js
@@ -1,27 +1,27 @@
 import chai from 'chai';
 import server from '../../server';
-import { API_ROUTE, JSON_ROUTE } from './constants';
+import { API_ROUTE, TEST_ROUTE } from './constants';
 import { createRegExp } from '../../controllers/words';
 import { resultsFromDictionarySearch } from '../../services/words';
 import mockedData from '../__mocks__/data.mock.json';
 
-/* Hits the POST /populate route to seed the local database */
-export const populateAPI = () => {
-    return chai.request(server)
-        .post(`${API_ROUTE}/populate`);
-};
-
 /* Uses the data in MongoDB */
 export const searchAPITerm = (term) => {
     return chai.request(server)
-        .get(`${API_ROUTE}/words`)
+        .get(API_ROUTE)
         .query({ keyword: term });
+};
+
+/* Hits the POST /populate route to seed the local MongoDB database */
+export const populateAPI = () => {
+    return chai.request(server)
+        .post(`${TEST_ROUTE}/populate`);
 };
 
 /* Uses data in JSON */
 export const searchTerm = (term) => {
     return chai.request(server)
-                .get(JSON_ROUTE)
+                .get(`${TEST_ROUTE}/words`)
                 .query({ keyword: term });
 };
 

--- a/tests/shared/constants.js
+++ b/tests/shared/constants.js
@@ -1,3 +1,3 @@
 export const LONG_TIMEOUT = 30000;
-export const API_ROUTE = '/api/v1/test';
-export const JSON_ROUTE = '/api/v1/search/words';
+export const API_ROUTE = '/api/v1/search/words';
+export const TEST_ROUTE = '/api/v1/test';


### PR DESCRIPTION
The express routes have been switched. Now the routes are as follows:

`api/v1/search/words` returns word data from the local MongoDB database

`api/v1/test/words` returns wor data from the JSON dictionary

Closes #51 