### PR TITLE
Use English to Search for Igbo Terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ For example:
 http://localhost:8080/api/v1/search/words?keyword=agụū
 ```
 
+You can also search with English terms with the same route:
+
+```
+/api/v1/search/words?keyword=hunger
+```
+
 ### JSON Data
 
 If you don't want the API to serve the word data from MongoDB, you can use the follow route to get the words that are stored in the **JSON dictionary**:

--- a/tests/database.test.js
+++ b/tests/database.test.js
@@ -8,6 +8,8 @@ import { populateAPI, searchAPITerm } from './shared/commands';
 const { expect } = chai;
 const { ObjectId } = mongoose.Types;
 
+const WORD_KEYS = ['__v', 'definitions', 'phrases', 'examples', '_id', 'word', 'wordClass'];
+
 describe('Database', () => {
     before(function(done) {
         this.timeout(LONG_TIMEOUT);
@@ -60,7 +62,7 @@ describe('Database', () => {
                 expect(res.status).to.equal(200);
                 expect(res.body).to.have.lengthOf.at.least(2);
                 forEach(res.body, (word) => {
-                    expect(word).to.have.keys(['__v', 'definitions', 'phrases', 'examples', '_id', 'word', 'wordClass']);
+                    expect(word).to.have.keys(WORD_KEYS);
                 });
                 done();
             });
@@ -94,6 +96,32 @@ describe('Database', () => {
                 expect(res.body).to.be.an('array');
                 expect(res.body).to.have.lengthOf(2);
                 expect(res.body[0].word).to.equal('àkịkà');
+                done();
+            });
+        });
+
+        it('should return igbo words when given english with an exact match', (done) => {
+            const keyword = 'animal; meat';
+            searchAPITerm(keyword)
+            .end((_, res) => {
+                expect(res.status).to.equal(200);
+                expect(res.body).to.be.an('array');
+                expect(res.body).to.have.lengthOf(1);
+                expect(res.body[0].word).to.equal('anụ');
+                done();
+            });
+        });
+
+        it('should return igbo words when given english with a partial match', (done) => {
+            const keyword = 'animal';
+            searchAPITerm(keyword)
+            .end((_, res) => {
+                expect(res.status).to.equal(200);
+                expect(res.body).to.be.an('array');
+                expect(res.body).to.have.lengthOf.at.least(3);
+                forEach(res.body, (word) => {
+                    expect(word).to.have.keys(WORD_KEYS);
+                });
                 done();
             });
         });


### PR DESCRIPTION
If a user searches for an English term, the API will first treat that provided keyword as an Igbo word and search the database.
If there's no word responses, then the backend will search the database again but this time treating the provided keyword as an English term.

Closes #7 