### PR TITLE
Use babel in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
   "author": "Ijemma Onwuzulike",
   "license": "ISC",
   "dependencies": {
+    "@babel/cli": "^7.11.6",
+    "@babel/core": "^7.11.6",
+    "@babel/node": "^7.10.5",
+    "@babel/plugin-transform-runtime": "^7.11.5",
+    "@babel/preset-env": "^7.11.5",
     "express": "^4.17.1",
     "lodash": "^4.17.20",
     "mongoose": "^5.10.7",
@@ -42,11 +47,6 @@
     "yarn": "^1.22.10"
   },
   "devDependencies": {
-    "@babel/cli": "^7.11.6",
-    "@babel/core": "^7.11.6",
-    "@babel/node": "^7.10.5",
-    "@babel/plugin-transform-runtime": "^7.11.5",
-    "@babel/preset-env": "^7.11.5",
     "chai": "^4.2.0",
     "chai-http": "^4.3.0",
     "eslint": "^7.10.0",


### PR DESCRIPTION
In order for Heroku to have access to `babel`, it needs to be under `dependencies` instead of `devDependencies`