### PR TITLE
Ignore build and public files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@ bower_components
 # Compiled binary addons (https://nodejs.org/api/addons.html)
 build/Release
 
+# Built files
+build/
+public/
+
 # Dependency directories
 node_modules/
 jspm_packages/


### PR DESCRIPTION
Built files from the `gatsby-dev` branch might spill into other branches. To ensure that those files don't accidentally get included in PRs the `.gitignore` file is updated to ignore `build/` and `public/`