### PR TITLE
Remove _id and __v keys

### DIFF
--- a/src/models/Example.js
+++ b/src/models/Example.js
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose';
+import { toJSONPlugin } from './plugins';
 
 const { Schema, Types } = mongoose;
 const exampleSchema = new Schema({
@@ -6,5 +7,7 @@ const exampleSchema = new Schema({
   parentWord: { type: Types.ObjectId, ref: 'Word' },
   parentPhrase: { type: Types.ObjectId, ref: 'Phrase' },
 });
+
+toJSONPlugin(exampleSchema);
 
 export default mongoose.model('Example', exampleSchema);

--- a/src/models/Phrase.js
+++ b/src/models/Phrase.js
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose';
+import { toJSONPlugin } from './plugins';
 
 const { Schema, Types } = mongoose;
 const phraseSchema = new Schema({
@@ -7,5 +8,7 @@ const phraseSchema = new Schema({
   definitions: [{ type: String }],
   examples: [{ type: Types.ObjectId, ref: 'Example' }],
 });
+
+toJSONPlugin(phraseSchema);
 
 export default mongoose.model('Phrase', phraseSchema);

--- a/src/models/Word.js
+++ b/src/models/Word.js
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose';
+import { toJSONPlugin } from './plugins';
 
 const { Schema, Types } = mongoose;
 const wordSchema = new Schema({
@@ -9,5 +10,7 @@ const wordSchema = new Schema({
   examples: [{ type: Types.ObjectId, ref: 'Example' }],
   variations: [{ type: String }],
 });
+
+toJSONPlugin(wordSchema);
 
 export default mongoose.model('Word', wordSchema);

--- a/src/models/plugins/index.js
+++ b/src/models/plugins/index.js
@@ -1,0 +1,19 @@
+/* Code from https://stackoverflow.com/a/30435676 */
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable no-param-reassign */
+import mongoose from 'mongoose';
+
+/* Replaces the _id key with id */
+export const toJSONPlugin = (schema) => {
+  const toJSON = schema.methods.toJSON || mongoose.Document.prototype.toJSON;
+  schema.set('toJSON', {
+    virtuals: true,
+  });
+  schema.methods.toJSON = function () {
+    const json = toJSON.apply(this);
+    delete json._id;
+    delete json.__t;
+    delete json.__v;
+    return json;
+  };
+};


### PR DESCRIPTION
Now the API will return "cleaner" objects where there's no `__v` key and the `_id` has been replaced with `id`.

Close #79 