### PR TITLE
Igbo api 121 - GET routes word example suggestions

### DIFF
--- a/src/controllers/exampleSuggestions.js
+++ b/src/controllers/exampleSuggestions.js
@@ -1,4 +1,5 @@
-import { assign } from 'lodash';
+import mongoose from 'mongoose';
+import { assign, some } from 'lodash';
 import ExampleSuggestion from '../models/ExampleSuggestion';
 
 /* Creates a new ExampleSuggestion document in the database */
@@ -8,6 +9,11 @@ export const postExampleSuggestion = (req, res) => {
   if (!data.igbo && !data.english) {
     res.status(400);
     return res.send({ error: 'Required information is missing, double check your provided data' });
+  }
+
+  if (some(data.associatedWords, (associatedWord) => !mongoose.Types.ObjectId.isValid(associatedWord))) {
+    res.status(400);
+    return res.send({ error: 'Invalid id found in associatedWords' });
   }
 
   const newExampleSuggestion = new ExampleSuggestion(data);
@@ -52,3 +58,16 @@ export const getExampleSuggestions = (_, res) => (
       return res.send('An error has occurred while return example suggestions, double check your provided data');
     })
 );
+
+/* Returns a single ExampleSuggestion by using an id */
+export const getExampleSuggestion = (req, res) => {
+  const { id } = req.params;
+  return ExampleSuggestion.findById(id)
+    .then((exampleSuggestion) => (
+      res.send(exampleSuggestion)
+    ))
+    .catch(() => {
+      res.status(400);
+      return res.send({ error: 'An error has occurred while returning a single example suggestion' });
+    });
+};

--- a/src/controllers/exampleSuggestions.js
+++ b/src/controllers/exampleSuggestions.js
@@ -35,9 +35,20 @@ export const putExampleSuggestion = (req, res) => {
       const updatedExampleSuggestion = assign(exampleSuggestion, data);
       res.send(await updatedExampleSuggestion.save());
     })
-    .catch((err) => {
-      console.log(err);
+    .catch(() => {
       res.status(400);
       return res.send('An error has occurred while updating, double check your provided data');
     });
 };
+
+/* Returns all existing ExampleSuggestion objects */
+export const getExampleSuggestions = (_, res) => (
+  ExampleSuggestion.find()
+    .then((exampleSuggestions) => (
+      res.send(exampleSuggestions)
+    ))
+    .catch(() => {
+      res.status(400);
+      return res.send('An error has occurred while return example suggestions, double check your provided data');
+    })
+);

--- a/src/controllers/wordSuggestions.js
+++ b/src/controllers/wordSuggestions.js
@@ -1,3 +1,4 @@
+import mongoose from 'mongoose';
 import {
   assign,
   every,
@@ -11,8 +12,14 @@ const REQUIRE_KEYS = ['id', 'word', 'wordClass', 'definitions'];
 /* Creates a new WordSuggestion document in the database */
 export const postWordSuggestion = (req, res) => {
   const { body: data } = req;
+
+  if (!mongoose.Types.ObjectId.isValid(data.originalWordId)) {
+    res.status(400);
+    return res.send({ error: 'Invalid word id provided' });
+  }
+
   const newWordSuggestion = new WordSuggestion(data);
-  newWordSuggestion.save()
+  return newWordSuggestion.save()
     .then((wordSuggestion) => (
       res.send({ id: wordSuggestion.id })
     ))
@@ -54,3 +61,16 @@ export const getWordSuggestions = (_, res) => (
       });
     })
 );
+
+/* Returns a single WordSuggestion by using an id */
+export const getWordSuggestion = (req, res) => {
+  const { id } = req.params;
+  return WordSuggestion.findById(id)
+    .then((wordSuggestion) => (
+      res.send(wordSuggestion)
+    ))
+    .catch(() => {
+      res.status(400);
+      return res.send({ error: 'An error has occurred while returning a single word suggestion' });
+    });
+};

--- a/src/controllers/wordSuggestions.js
+++ b/src/controllers/wordSuggestions.js
@@ -40,3 +40,17 @@ export const putWordSuggestion = (req, res) => {
       return res.send({ error: 'An error has occurred while updating, double check your provided data' });
     });
 };
+
+/* Returns all existing WordSuggestion objects */
+export const getWordSuggestions = (_, res) => (
+  WordSuggestion.find()
+    .then((wordSuggestions) => (
+      res.send(wordSuggestions)
+    ))
+    .catch(() => {
+      res.status(400);
+      return res.send({
+        error: 'An error has occurred while returning word suggestions',
+      });
+    })
+);

--- a/src/routers/editRouter.js
+++ b/src/routers/editRouter.js
@@ -1,6 +1,6 @@
 import express from 'express';
-import { postWordSuggestion, putWordSuggestion } from '../controllers/wordSuggestions';
-import { postExampleSuggestion, putExampleSuggestion } from '../controllers/exampleSuggestions';
+import { postWordSuggestion, putWordSuggestion, getWordSuggestions } from '../controllers/wordSuggestions';
+import { getExampleSuggestions, postExampleSuggestion, putExampleSuggestion } from '../controllers/exampleSuggestions';
 
 const editRouter = express.Router();
 
@@ -78,13 +78,27 @@ if (process.env.NODE_ENV !== 'production') { // TODO: remove this guard rail whe
  *          application/json:
  *            schema:
  *              type: object
+ *   get:
+ *      description: Returns all WordSuggestion objects in the database
+ *      tags:
+ *       - development
+ *      consumes:
+ *        - application/json
+ *      responses:
+ *        200:
+ *         description: OK
+ *         content:
+ *          application/json:
+ *            schema:
+ *              type: object
  */
   editRouter.post('/words', postWordSuggestion);
   editRouter.put('/words', putWordSuggestion);
+  editRouter.get('/words', getWordSuggestions);
 
   /**
  * @swagger
- * /edit/example:
+ * /edit/examples:
  *   post:
  *     description: Creates a new ExampleSuggestion document
  *     tags:
@@ -146,9 +160,23 @@ if (process.env.NODE_ENV !== 'production') { // TODO: remove this guard rail whe
  *          application/json:
  *            schema:
  *              type: object
+ *   get:
+ *      description: Returns all ExampleSuggestion objects in the database
+ *      tags:
+ *       - development
+ *      consumes:
+ *        - application/json
+ *      responses:
+ *        200:
+ *         description: OK
+ *         content:
+ *          application/json:
+ *            schema:
+ *              type: object
  */
   editRouter.post('/examples', postExampleSuggestion);
   editRouter.put('/examples', putExampleSuggestion);
+  editRouter.get('/examples', getExampleSuggestions);
 }
 
 export default editRouter;

--- a/src/routers/editRouter.js
+++ b/src/routers/editRouter.js
@@ -1,6 +1,16 @@
 import express from 'express';
-import { postWordSuggestion, putWordSuggestion, getWordSuggestions } from '../controllers/wordSuggestions';
-import { getExampleSuggestions, postExampleSuggestion, putExampleSuggestion } from '../controllers/exampleSuggestions';
+import {
+  getWordSuggestion,
+  getWordSuggestions,
+  postWordSuggestion,
+  putWordSuggestion,
+} from '../controllers/wordSuggestions';
+import {
+  getExampleSuggestion,
+  getExampleSuggestions,
+  postExampleSuggestion,
+  putExampleSuggestion,
+} from '../controllers/exampleSuggestions';
 
 const editRouter = express.Router();
 
@@ -91,10 +101,33 @@ if (process.env.NODE_ENV !== 'production') { // TODO: remove this guard rail whe
  *          application/json:
  *            schema:
  *              type: object
+ *
+ * /edit/words/{wordSuggestionId}:
+ *    get:
+ *      description: Returns a single WordSuggestion object from the database
+ *      tags:
+ *       - development
+ *      consumes:
+ *        - application/json
+ *      parameters:
+ *        - in: path
+ *          name: wordSuggestionId
+ *          required: true
+ *          schema:
+ *            type: string
+ *          description: the wordSuggestion id
+ *      responses:
+ *        200:
+ *         description: OK
+ *         content:
+ *          application/json:
+ *            schema:
+ *              type: object
  */
   editRouter.post('/words', postWordSuggestion);
   editRouter.put('/words', putWordSuggestion);
   editRouter.get('/words', getWordSuggestions);
+  editRouter.get('/words/:id', getWordSuggestion);
 
   /**
  * @swagger
@@ -173,10 +206,33 @@ if (process.env.NODE_ENV !== 'production') { // TODO: remove this guard rail whe
  *          application/json:
  *            schema:
  *              type: object
+ *
+ * /edit/examples/{exampleSuggestionId}:
+ *    get:
+ *      description: Returns a single ExampleSuggestion object from the database
+ *      tags:
+ *       - development
+ *      consumes:
+ *        - application/json
+ *      parameters:
+ *        - in: path
+ *          name: exampleSuggestionId
+ *          required: true
+ *          schema:
+ *            type: string
+ *          description: the exampleSuggestion id
+ *      responses:
+ *        200:
+ *         description: OK
+ *         content:
+ *          application/json:
+ *            schema:
+ *              type: object
  */
   editRouter.post('/examples', postExampleSuggestion);
   editRouter.put('/examples', putExampleSuggestion);
   editRouter.get('/examples', getExampleSuggestions);
+  editRouter.get('/examples/:id', getExampleSuggestion);
 }
 
 export default editRouter;

--- a/tests/__mocks__/suggestions.js
+++ b/tests/__mocks__/suggestions.js
@@ -2,7 +2,9 @@ import mongoose from 'mongoose';
 
 const { ObjectId } = mongoose.Types;
 
+const wordId = new ObjectId('5f864d7401203866b6546dd3');
 const wordSuggestionData = {
+  originalWordId: wordId,
   word: 'word',
   wordClass: 'wordClass',
   definitions: ['first'],

--- a/tests/shared/commands.js
+++ b/tests/shared/commands.js
@@ -5,6 +5,30 @@ import createRegExp from '../../src/shared/utils/createRegExp';
 import { resultsFromDictionarySearch } from '../../src/services/words';
 import mockedData from '../__mocks__/data.mock.json';
 
+export const getWordSuggestions = () => (
+  chai
+    .request(server)
+    .get(`${EDIT_API_ROUTE}/words`)
+);
+
+export const getWordSuggestion = (id) => (
+  chai
+    .request(server)
+    .get(`${EDIT_API_ROUTE}/words/${id}`)
+);
+
+export const getExampleSuggestions = () => (
+  chai
+    .request(server)
+    .get(`${EDIT_API_ROUTE}/examples`)
+);
+
+export const getExampleSuggestion = (id) => (
+  chai
+    .request(server)
+    .get(`${EDIT_API_ROUTE}/examples/${id}`)
+);
+
 export const suggestNewWord = (data) => (
   chai
     .request(server)

--- a/tests/wordSuggestions.test.js
+++ b/tests/wordSuggestions.test.js
@@ -1,8 +1,10 @@
 import chai from 'chai';
-import { forIn, isEqual } from 'lodash';
+import { forEach, forIn, isEqual } from 'lodash';
 import {
   suggestNewWord,
   updateWordSuggestion,
+  getWordSuggestions,
+  getWordSuggestion,
 } from './shared/commands';
 import {
   wordSuggestionData,
@@ -11,6 +13,20 @@ import {
 } from './__mocks__/suggestions';
 
 const { expect } = chai;
+
+const WORD_SUGGESTION_KEYS = [
+  'originalWordId',
+  'word',
+  'wordClass',
+  'definitions',
+  'variations',
+  'details',
+  'approvals',
+  'denials',
+  'updatedOn',
+  'merged',
+  'id',
+];
 
 describe('MongoDB Word Suggestions', () => {
   describe('/POST mongodb wordSuggestions', () => {
@@ -25,6 +41,16 @@ describe('MongoDB Word Suggestions', () => {
 
     it('should return a word error because of malformed data', (done) => {
       suggestNewWord(malformedWordSuggestionData)
+        .end((_, res) => {
+          expect(res.status).to.equal(400);
+          expect(res.body.error).to.not.equal(undefined);
+          done();
+        });
+    });
+
+    it.only('should return a word error because invalid id', (done) => {
+      const malformedData = { ...wordSuggestionData, originalWordId: 'ok123' };
+      suggestNewWord(malformedData)
         .end((_, res) => {
           expect(res.status).to.equal(400);
           expect(res.body.error).to.not.equal(undefined);
@@ -60,6 +86,36 @@ describe('MongoDB Word Suggestions', () => {
               done();
             });
         });
+    });
+
+    describe('/GET mongodb wordSuggestions', () => {
+      it.only('should return all word suggestions', (done) => {
+        Promise.all([suggestNewWord(wordSuggestionData), suggestNewWord(wordSuggestionData)])
+          .then(() => {
+            getWordSuggestions()
+              .end((_, res) => {
+                expect(res.status).to.equal(200);
+                expect(res.body).to.have.lengthOf(2);
+                forEach(res.body, (wordSuggestion) => {
+                  expect(wordSuggestion).to.have.all.keys(WORD_SUGGESTION_KEYS);
+                });
+                done();
+              });
+          });
+      });
+
+      it.only('should return one word suggestion', (done) => {
+        suggestNewWord(wordSuggestionData)
+          .then((res) => {
+            getWordSuggestion(res.body.id)
+              .end((_, result) => {
+                expect(result.status).to.equal(200);
+                expect(result.body).to.be.an('object');
+                expect(result.body).to.have.all.keys(WORD_SUGGESTION_KEYS);
+                done();
+              });
+          });
+      });
     });
   });
 });


### PR DESCRIPTION
Create /GET routes for `WordSuggestion` and `ExampleSuggestion` documents. There's also the ability to search for individual `WordSuggestion` and `ExampleSuggestion` documents with the `/:id` path

Closes #121 