### PR TITLE
Igbo api - supply content range header

### DIFF
--- a/src/controllers/exampleSuggestions.js
+++ b/src/controllers/exampleSuggestions.js
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose';
 import { assign, some } from 'lodash';
 import ExampleSuggestion from '../models/ExampleSuggestion';
-import { paginate } from './utils/index';
+import { paginate, convertRangeToPage } from './utils';
 
 /* Creates a new ExampleSuggestion document in the database */
 export const postExampleSuggestion = (req, res) => {
@@ -50,8 +50,8 @@ export const putExampleSuggestion = (req, res) => {
 
 /* Returns all existing ExampleSuggestion objects */
 export const getExampleSuggestions = (req, res) => {
-  const { page: pageQuery } = req.query;
-  const page = parseInt(pageQuery, 10) || 0;
+  const { page: pageQuery, range } = req.query;
+  const page = parseInt(pageQuery, 10) || convertRangeToPage(range) || 0;
   ExampleSuggestion.find()
     .then((exampleSuggestions) => (
       paginate(res, exampleSuggestions, page)

--- a/src/controllers/genericWords.js
+++ b/src/controllers/genericWords.js
@@ -2,12 +2,12 @@ import { forIn } from 'lodash';
 import GenericWord from '../models/GenericWord';
 import testGenericWordsDictionary from '../../tests/__mocks__/genericWords.mock.json';
 import genericWordsDictionary from '../dictionaries/ig-en/ig-en_normalized_expanded.json';
-import { paginate } from './utils/index';
+import { paginate, convertRangeToPage } from './utils';
 
 /* Returns all existing GenericWord objects */
 export const getGenericWords = (req, res) => {
-  const { page: pageQuery } = req.query;
-  const page = parseInt(pageQuery, 10) || 0;
+  const { page: pageQuery, range } = req.query;
+  const page = parseInt(pageQuery, 10) || convertRangeToPage(range) || 0;
   return GenericWord.find()
     .then((genericWords) => (
       paginate(res, genericWords, page)

--- a/src/controllers/utils/index.js
+++ b/src/controllers/utils/index.js
@@ -18,6 +18,15 @@ export const sortDocsByDefinitions = (searchWord, docs) => {
 };
 
 /* Wrapper function to prep response by limiting number of docs return to the client */
-export const paginate = (res, docs, page) => (
-  res.send(docs.slice(page * RESPONSE_LIMIT, RESPONSE_LIMIT * (page + 1)))
-);
+export const paginate = (res, docs, page) => {
+  res.setHeader('Content-Range', docs.length);
+  return res.send(docs.slice(page * RESPONSE_LIMIT, RESPONSE_LIMIT * (page + 1)));
+};
+
+export const convertRangeToPage = (range = '[0,10]') => {
+  try {
+    return parseInt(range.substring(range.indexOf('[') + 1, range.indexOf(',')), 10) / 10;
+  } catch {
+    return 0;
+  }
+};

--- a/src/controllers/wordSuggestions.js
+++ b/src/controllers/wordSuggestions.js
@@ -6,7 +6,7 @@ import {
   partial,
 } from 'lodash';
 import WordSuggestion from '../models/WordSuggestion';
-import { paginate } from './utils/index';
+import { paginate, convertRangeToPage } from './utils';
 
 const REQUIRE_KEYS = ['id', 'word', 'wordClass', 'definitions'];
 
@@ -51,8 +51,8 @@ export const putWordSuggestion = (req, res) => {
 
 /* Returns all existing WordSuggestion objects */
 export const getWordSuggestions = (req, res) => {
-  const { page: pageQuery } = req.query;
-  const page = parseInt(pageQuery, 10) || 0;
+  const { page: pageQuery, range } = req.query;
+  const page = parseInt(pageQuery, 10) || convertRangeToPage(range) || 0;
   WordSuggestion.find()
     .then((wordSuggestions) => (
       paginate(res, wordSuggestions, page)

--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -6,7 +6,12 @@ import { NO_PROVIDED_TERM } from '../shared/constants/errorMessages';
 import { getDocumentsIds } from '../shared/utils/documentUtils';
 import { POPULATE_EXAMPLE } from '../shared/constants/populateDocuments';
 import createRegExp from '../shared/utils/createRegExp';
-import { createQueryRegex, sortDocsByDefinitions, paginate } from './utils';
+import {
+  createQueryRegex,
+  sortDocsByDefinitions,
+  paginate,
+  convertRangeToPage,
+} from './utils';
 import { createExample } from './examples';
 
 /* Gets words from JSON dictionary */
@@ -43,9 +48,9 @@ const getWordsUsingEnglish = async (res, regex, searchWord, page) => {
 
 /* Gets words from MongoDB */
 export const getWords = async (req, res) => {
-  const { keyword = '', page: pageQuery } = req.query;
+  const { keyword = '', page: pageQuery, range } = req.query;
   const searchWord = removePrefix(keyword || '');
-  const page = parseInt(pageQuery, 10) || 0;
+  const page = parseInt(pageQuery, 10) || convertRangeToPage(range) || 0;
   const regexKeyword = createQueryRegex(searchWord);
   const words = await searchWordUsingIgbo(regexKeyword);
 

--- a/src/server.js
+++ b/src/server.js
@@ -24,7 +24,9 @@ db.once('open', () => {
   console.log('🗄 Database is connected');
 });
 
-app.use(cors());
+app.use(cors({
+  exposedHeaders: ['Content-Range', 'X-Content-Range'],
+}));
 
 app.get('/', (_, res) => {
   res.send('Hello World!');

--- a/tests/genericWords.test.js
+++ b/tests/genericWords.test.js
@@ -1,7 +1,5 @@
 import chai from 'chai';
 import {
-  map,
-  difference,
   forEach,
   isEqual,
 } from 'lodash';
@@ -11,6 +9,7 @@ import {
   getGenericWord,
 } from './shared/commands';
 import { LONG_TIMEOUT } from './shared/constants';
+import expectUniqSetsOfResponses from './shared/utils';
 
 const { expect } = chai;
 
@@ -65,18 +64,22 @@ describe('MongoDB Generic Words', () => {
 
     it('should return different sets of generic words for pagination', (done) => {
       Promise.all([
+        getGenericWords({ range: '[0,9]' }),
+        getGenericWords({ range: '[10,19]' }),
+        getGenericWords({ range: '[20,29' }),
+      ]).then((res) => {
+        expectUniqSetsOfResponses(res);
+        done();
+      });
+    });
+
+    it('should return different sets of generic words for pagination', (done) => {
+      Promise.all([
         getGenericWords(0),
         getGenericWords(1),
         getGenericWords(2),
       ]).then((res) => {
-        forEach(res, (wordsRes, index) => {
-          expect(wordsRes.status).to.equal(200);
-          if (index !== 0) {
-            const prevWordIds = map(res[index].body, ({ id }) => ({ id }));
-            const currentWordIds = map(wordsRes.body, ({ id }) => ({ id }));
-            expect(difference(prevWordIds, currentWordIds)).to.have.lengthOf(prevWordIds.length);
-          }
-        });
+        expectUniqSetsOfResponses(res);
         done();
       });
     });

--- a/tests/shared/utils.js
+++ b/tests/shared/utils.js
@@ -1,0 +1,18 @@
+import chai from 'chai';
+import { difference, forEach, map } from 'lodash';
+
+const { expect } = chai;
+
+const expectUniqSetsOfResponses = (res) => {
+  forEach(res, (docsRes, index) => {
+    expect(docsRes.status).to.equal(200);
+    expect(docsRes.body).to.have.lengthOf.at.most(10);
+    if (index !== 0) {
+      const prevDocsIds = map(res[index].body, ({ id }) => ({ id }));
+      const currentDocsIds = map(docsRes.body, ({ id }) => ({ id }));
+      expect(difference(prevDocsIds, currentDocsIds)).to.have.lengthOf(prevDocsIds.length);
+    }
+  });
+};
+
+export default expectUniqSetsOfResponses;


### PR DESCRIPTION
In order for the frontend to know what the total number of words or other documents exist in the database, the `Content-Range` header needs to be defined.

The API can now use the `range` query to paginate through response bodies.