### PR TITLE
Igbo api 130/Search word and example suggestions

### DIFF
--- a/src/controllers/exampleSuggestions.js
+++ b/src/controllers/exampleSuggestions.js
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose';
 import { assign, some } from 'lodash';
 import ExampleSuggestion from '../models/ExampleSuggestion';
-import { paginate, convertRangeToPage } from './utils';
+import { paginate, handleQueries } from './utils';
 
 /* Creates a new ExampleSuggestion document in the database */
 export const postExampleSuggestion = (req, res) => {
@@ -50,9 +50,8 @@ export const putExampleSuggestion = (req, res) => {
 
 /* Returns all existing ExampleSuggestion objects */
 export const getExampleSuggestions = (req, res) => {
-  const { page: pageQuery, range } = req.query;
-  const page = parseInt(pageQuery, 10) || convertRangeToPage(range) || 0;
-  ExampleSuggestion.find()
+  const { regexKeyword, page } = handleQueries(req.query);
+  ExampleSuggestion.find({ $or: [{ igbo: regexKeyword }, { english: regexKeyword }] })
     .then((exampleSuggestions) => (
       paginate(res, exampleSuggestions, page)
     ))

--- a/src/controllers/genericWords.js
+++ b/src/controllers/genericWords.js
@@ -2,13 +2,12 @@ import { forIn } from 'lodash';
 import GenericWord from '../models/GenericWord';
 import testGenericWordsDictionary from '../../tests/__mocks__/genericWords.mock.json';
 import genericWordsDictionary from '../dictionaries/ig-en/ig-en_normalized_expanded.json';
-import { paginate, convertRangeToPage } from './utils';
+import { paginate, handleQueries } from './utils';
 
 /* Returns all existing GenericWord objects */
 export const getGenericWords = (req, res) => {
-  const { page: pageQuery, range } = req.query;
-  const page = parseInt(pageQuery, 10) || convertRangeToPage(range) || 0;
-  return GenericWord.find()
+  const { regexKeyword, page } = handleQueries(req.query);
+  return GenericWord.find({ word: regexKeyword })
     .then((genericWords) => (
       paginate(res, genericWords, page)
     ))

--- a/src/controllers/utils/index.js
+++ b/src/controllers/utils/index.js
@@ -1,4 +1,5 @@
 import stringSimilarity from 'string-similarity';
+import removePrefix from '../../shared/utils/removePrefix';
 import createRegExp from '../../shared/utils/createRegExp';
 
 const RESPONSE_LIMIT = 10;
@@ -23,10 +24,20 @@ export const paginate = (res, docs, page) => {
   return res.send(docs.slice(page * RESPONSE_LIMIT, RESPONSE_LIMIT * (page + 1)));
 };
 
+/* Converts the range query into a number to be used as the page query */
 export const convertRangeToPage = (range = '[0,10]') => {
   try {
     return parseInt(range.substring(range.indexOf('[') + 1, range.indexOf(',')), 10) / 10;
   } catch {
     return 0;
   }
+};
+
+/* Handles all the queries for searching in the database */
+export const handleQueries = (query = {}) => {
+  const { keyword = '', page: pageQuery = '', range } = query;
+  const searchWord = removePrefix(keyword || '');
+  const regexKeyword = createQueryRegex(searchWord);
+  const page = parseInt(pageQuery, 10) || convertRangeToPage(range) || 0;
+  return { searchWord, regexKeyword, page };
 };

--- a/src/controllers/wordSuggestions.js
+++ b/src/controllers/wordSuggestions.js
@@ -6,7 +6,7 @@ import {
   partial,
 } from 'lodash';
 import WordSuggestion from '../models/WordSuggestion';
-import { paginate, convertRangeToPage } from './utils';
+import { paginate, handleQueries } from './utils';
 
 const REQUIRE_KEYS = ['id', 'word', 'wordClass', 'definitions'];
 
@@ -51,9 +51,8 @@ export const putWordSuggestion = (req, res) => {
 
 /* Returns all existing WordSuggestion objects */
 export const getWordSuggestions = (req, res) => {
-  const { page: pageQuery, range } = req.query;
-  const page = parseInt(pageQuery, 10) || convertRangeToPage(range) || 0;
-  WordSuggestion.find()
+  const { regexKeyword, page } = handleQueries(req.query);
+  WordSuggestion.find({ word: regexKeyword })
     .then((wordSuggestions) => (
       paginate(res, wordSuggestions, page)
     ))

--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -7,10 +7,9 @@ import { getDocumentsIds } from '../shared/utils/documentUtils';
 import { POPULATE_EXAMPLE } from '../shared/constants/populateDocuments';
 import createRegExp from '../shared/utils/createRegExp';
 import {
-  createQueryRegex,
   sortDocsByDefinitions,
   paginate,
-  convertRangeToPage,
+  handleQueries,
 } from './utils';
 import { createExample } from './examples';
 
@@ -48,10 +47,7 @@ const getWordsUsingEnglish = async (res, regex, searchWord, page) => {
 
 /* Gets words from MongoDB */
 export const getWords = async (req, res) => {
-  const { keyword = '', page: pageQuery, range } = req.query;
-  const searchWord = removePrefix(keyword || '');
-  const page = parseInt(pageQuery, 10) || convertRangeToPage(range) || 0;
-  const regexKeyword = createQueryRegex(searchWord);
+  const { searchWord, regexKeyword, page } = handleQueries(req.query);
   const words = await searchWordUsingIgbo(regexKeyword);
 
   if (!words.length) {

--- a/tests/exampleSuggestions.test.js
+++ b/tests/exampleSuggestions.test.js
@@ -98,6 +98,23 @@ describe('MongoDB Example Suggestions', () => {
   });
 
   describe('/GET mongodb exampleSuggestions', () => {
+    it('should return an example suggestion by searching', (done) => {
+      const exampleText = exampleSuggestionData.igbo;
+      suggestNewExample(exampleSuggestionData)
+        .then(() => {
+          getExampleSuggestions({ keyword: exampleText })
+            .end((_, res) => {
+              expect(res.status).to.equal(200);
+              expect(res.body).to.be.an('array');
+              expect(res.body).to.have.lengthOf.at.least(1);
+              forEach(Object.keys(exampleSuggestionData), (key) => {
+                expect(res.body[0][key]).to.equal(exampleSuggestionData[key]);
+              });
+              done();
+            });
+        });
+    });
+
     it('should return all example suggestions', (done) => {
       Promise.all([suggestNewExample(exampleSuggestionData), suggestNewExample(exampleSuggestionData)])
         .then(() => {

--- a/tests/exampleSuggestions.test.js
+++ b/tests/exampleSuggestions.test.js
@@ -104,7 +104,7 @@ describe('MongoDB Example Suggestions', () => {
           getExampleSuggestions()
             .end((_, res) => {
               expect(res.status).to.equal(200);
-              expect(res.body).to.have.lengthOf.at.least(5);
+              expect(res.body).to.have.lengthOf.at.least(2);
               forEach(res.body, (exampleSuggestion) => {
                 expect(exampleSuggestion).to.have.all.keys(EXAMPLE_SUGGESTION_KEYS);
               });

--- a/tests/genericWords.test.js
+++ b/tests/genericWords.test.js
@@ -35,6 +35,18 @@ describe('MongoDB Generic Words', () => {
   });
 
   describe('/GET mongodb genericWords', () => {
+    it('should return a generic word by searching', (done) => {
+      const keyword = 'mbughari';
+      getGenericWords({ keyword })
+        .end((_, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body).to.be.an('array');
+          expect(res.body).to.have.lengthOf.at.least(1);
+          expect(res.body[0].word).to.equal(keyword);
+          done();
+        });
+    });
+
     it('should return all generic words', (done) => {
       getGenericWords()
         .end((_, res) => {

--- a/tests/wordSuggestions.test.js
+++ b/tests/wordSuggestions.test.js
@@ -96,6 +96,21 @@ describe('MongoDB Word Suggestions', () => {
   });
 
   describe('/GET mongodb wordSuggestions', () => {
+    it('should return an example by searching', (done) => {
+      const keyword = wordSuggestionData.word;
+      suggestNewWord(wordSuggestionData)
+        .then(() => {
+          getWordSuggestions({ keyword })
+            .end((_, res) => {
+              expect(res.status).to.equal(200);
+              expect(res.body).to.be.an('array');
+              expect(res.body).to.have.lengthOf.at.least(1);
+              expect(res.body[0].word).to.equal(keyword);
+              done();
+            });
+        });
+    });
+
     it('should return all word suggestions', (done) => {
       Promise.all([suggestNewWord(wordSuggestionData), suggestNewWord(wordSuggestionData)])
         .then(() => {


### PR DESCRIPTION
The `WordSuggestion`, `ExampleSuggestion`, and `GenericWord` get routes can now take the `keyword` query to be able to  use the document's `word`, `igbo`, and `english` keys for search

Closes #95 
Closes #130 