### PR TITLE
Igbo api 142/get examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ For example:
 http://localhost:8080/api/v1/words?keyword=agụū&page=1
 ```
 
+You can also search for examples using:
+
+```
+/api/v1/examples?keyword<keyword>&page=<page>
+```
+
 ### JSON Data
 
 If you don't want the API to serve the word data from MongoDB, you can use the follow route to get the words that are stored in the **JSON dictionary**:

--- a/src/controllers/examples.js
+++ b/src/controllers/examples.js
@@ -1,6 +1,20 @@
 import Example from '../models/Example';
+import { paginate, handleQueries } from './utils';
 
+/* Create a new Example object in MongoDB */
 export const createExample = (data) => {
   const example = new Example(data);
   return example.save();
+};
+
+const searchExamples = (regex) => (
+  Example
+    .find({ $or: [{ igbo: regex }, { english: regex }] })
+);
+
+export const getExamples = async (req, res) => {
+  const { regexKeyword, page } = handleQueries(req.query);
+  const examples = await searchExamples(regexKeyword);
+
+  return paginate(res, examples, page);
 };

--- a/src/routers/router.js
+++ b/src/routers/router.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import { getWords } from '../controllers/words';
+import { getExamples } from '../controllers/examples';
 
 const router = express.Router();
 
@@ -12,7 +13,32 @@ const router = express.Router();
  *      - production
  *     parameters:
  *      - name: keyword
- *        description: keyword for querying dictionary
+ *        description: keyword for querying words
+ *        in: query
+ *        required: false
+ *        type: string
+ *      - name: page
+ *        description: page for results
+ *        in: query
+ *        required: false
+ *        type: integer
+ *      - name: range
+ *        description: page for results using [x,y] syntax
+ *        in: query
+ *        required: false
+ *        type: string
+ *     responses:
+ *      200:
+ *         description: OK
+ *
+ * /examples:
+ *   get:
+ *     description: Get examples in dictionary
+  *     tags:
+ *      - production
+ *     parameters:
+ *      - name: keyword
+ *        description: keyword for querying examples
  *        in: query
  *        required: false
  *        type: string
@@ -31,5 +57,6 @@ const router = express.Router();
  *         description: OK
  */
 router.get('/words', getWords);
+router.get('/examples', getExamples);
 
 export default router;

--- a/tests/exampleSuggestions.test.js
+++ b/tests/exampleSuggestions.test.js
@@ -165,5 +165,15 @@ describe('MongoDB Example Suggestions', () => {
         done();
       });
     });
+
+    it('should return prioritize page over range', (done) => {
+      Promise.all([
+        getExampleSuggestions({ page: '1' }),
+        getExampleSuggestions({ page: '1', range: '[100,109]' }),
+      ]).then((res) => {
+        expect(isEqual(res[0].body, res[1].body)).to.equal(true);
+        done();
+      });
+    });
   });
 });

--- a/tests/examples.test.js
+++ b/tests/examples.test.js
@@ -1,0 +1,53 @@
+import chai from 'chai';
+import { isEqual } from 'lodash';
+import { getExamples } from './shared/commands';
+import { LONG_TIMEOUT } from './shared/constants';
+import expectUniqSetsOfResponses from './shared/utils';
+
+const { expect } = chai;
+
+describe('MongoDB Examples', () => {
+  describe('/GET mongodb examples', () => {
+    it('should return an example by searching', (done) => {
+      getExamples()
+        .end((_, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body).to.have.lengthOf.at.most(10);
+          done();
+        });
+    });
+
+    it('should return at most ten example per request with range query', function (done) {
+      this.timeout(LONG_TIMEOUT);
+      Promise.all([
+        getExamples({ range: '[0,9]' }),
+        getExamples({ range: '[10,19]' }),
+        getExamples({ range: '[20,29' }),
+      ]).then((res) => {
+        expectUniqSetsOfResponses(res);
+        done();
+      });
+    });
+
+    it('should return different sets of example suggestions for pagination', (done) => {
+      Promise.all([
+        getExamples(0),
+        getExamples(1),
+        getExamples(2),
+      ]).then((res) => {
+        expectUniqSetsOfResponses(res);
+        done();
+      });
+    });
+
+    it('should return prioritize page over range', (done) => {
+      Promise.all([
+        getExamples({ page: '1' }),
+        getExamples({ page: '1', range: '[100,109]' }),
+      ]).then((res) => {
+        expect(isEqual(res[0].body, res[1].body)).to.equal(true);
+        done();
+      });
+    });
+  });
+});

--- a/tests/genericWords.test.js
+++ b/tests/genericWords.test.js
@@ -95,5 +95,15 @@ describe('MongoDB Generic Words', () => {
         done();
       });
     });
+
+    it('should return prioritize page over range', (done) => {
+      Promise.all([
+        getGenericWords({ page: '1' }),
+        getGenericWords({ page: '1', range: '[100,109]' }),
+      ]).then((res) => {
+        expect(isEqual(res[0].body, res[1].body)).to.equal(true);
+        done();
+      });
+    });
   });
 });

--- a/tests/shared/commands.js
+++ b/tests/shared/commands.js
@@ -73,10 +73,18 @@ export const updateExampleSuggestion = (data) => (
 );
 
 /* Searches for words using the data in MongoDB */
-export const searchAPIByWord = (query = {}) => (
+export const getWords = (query = {}) => (
   chai
     .request(server)
     .get(`${API_ROUTE}/words`)
+    .query(query)
+);
+
+/* Searches for examples using the data in MongoDB */
+export const getExamples = (query = {}) => (
+  chai
+    .request(server)
+    .get(`${API_ROUTE}/examples`)
     .query(query)
 );
 

--- a/tests/wordSuggestions.test.js
+++ b/tests/wordSuggestions.test.js
@@ -161,5 +161,15 @@ describe('MongoDB Word Suggestions', () => {
         done();
       });
     });
+
+    it('should return prioritize page over range', (done) => {
+      Promise.all([
+        getWordSuggestions({ page: '1' }),
+        getWordSuggestions({ page: '1', range: '[100,109]' }),
+      ]).then((res) => {
+        expect(isEqual(res[0].body, res[1].body)).to.equal(true);
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR creates a new route `api/v1/examples` that allows developers to see the examples offered in the API

Closes #142 