### PR TITLE
Igbo api 147/post words examples

### DIFF
--- a/src/controllers/examples.js
+++ b/src/controllers/examples.js
@@ -1,3 +1,5 @@
+import mongoose from 'mongoose';
+import { some } from 'lodash';
 import Example from '../models/Example';
 import { paginate, handleQueries } from './utils';
 
@@ -7,14 +9,45 @@ export const createExample = (data) => {
   return example.save();
 };
 
+/* Uses regex to search for examples with both Igbo and English */
 const searchExamples = (regex) => (
   Example
     .find({ $or: [{ igbo: regex }, { english: regex }] })
 );
 
+/* Returns examples from MongoDB */
 export const getExamples = async (req, res) => {
   const { regexKeyword, page } = handleQueries(req.query);
   const examples = await searchExamples(regexKeyword);
 
   return paginate(res, examples, page);
+};
+
+/* Call the createExample helper function and returns status to client */
+export const postExample = (req, res) => {
+  const { body: data } = req;
+
+  if (!data.igbo && !data.english) {
+    res.status(400);
+    return res.send({ error: 'Required information is missing, double check your provided data' });
+  }
+
+  if (some(data.associatedWords, (associatedWord) => !mongoose.Types.ObjectId.isValid(associatedWord))) {
+    res.status(400);
+    return res.send({ error: 'Invalid id found in associatedWords' });
+  }
+
+  try {
+    return createExample(data)
+      .then((example) => (
+        res.send({ id: example.id })
+      ))
+      .catch(() => {
+        res.status(400);
+        return res.send({ error: 'An error occurred while saving the new example.' });
+      });
+  } catch {
+    res.send(400);
+    return res.send({ error: 'An error has occurred during the example creation process.' });
+  }
 };

--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -91,3 +91,27 @@ export const createWord = async (data) => {
   newWord.examples = exampleIds;
   return newWord.save();
 };
+
+/* Call the createWord helper function and returns status to client */
+export const postWord = (req, res) => {
+  const { body: data } = req;
+
+  if (!data.word) {
+    res.status(400);
+    return res.send({ error: 'The word property is missing, double check your provided data' });
+  }
+
+  try {
+    return createWord(data)
+      .then((word) => (
+        res.send({ id: word.id })
+      ))
+      .catch(() => {
+        res.status(400);
+        return res.send({ error: 'An error occurred while saving the new word.' });
+      });
+  } catch {
+    res.send(400);
+    return res.send({ error: 'An error has occurred during the word and example creation process.' });
+  }
+};

--- a/src/routers/router.js
+++ b/src/routers/router.js
@@ -9,7 +9,7 @@ const router = express.Router();
  * /words:
  *   get:
  *     description: Get words in dictionary
-  *     tags:
+ *     tags:
  *      - production
  *     parameters:
  *      - name: keyword
@@ -30,6 +30,42 @@ const router = express.Router();
  *     responses:
  *      200:
  *         description: OK
+ *
+ *   post:
+ *     description: Creates a new Word document
+ *     tags:
+ *      - development
+ *     consumes:
+ *       - application/json
+ *     parameters:
+ *       - in: body
+ *         name: body
+ *         description: The word that will be created in the database
+ *         schema:
+ *           type: object
+ *           properties:
+ *             word:
+ *               type: string
+ *             wordClass:
+ *               type: string
+ *             definitions:
+ *               type: array
+ *               items:
+ *                 type: string
+ *             variations:
+ *               type: array
+ *               items:
+ *                 type: string
+ *     responses:
+ *      200:
+ *         description: OK
+ *         content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                id:
+ *                type: string
  *
  * /examples:
  *   get:
@@ -55,6 +91,28 @@ const router = express.Router();
  *     responses:
  *      200:
  *         description: OK
+ *
+ *   post:
+ *     description: Creates a new Example document
+ *     tags:
+ *      - development
+ *     consumes:
+ *       - application/json
+ *     parameters:
+ *       - in: body
+ *         name: body
+ *         description: The example that will be created in the database
+ *         schema:
+ *           type: object
+ *           properties:
+ *             igbo:
+ *               type: string
+ *             english:
+ *               type: string
+ *             associatedWords:
+ *               type: array
+ *               items:
+ *                 type: string
  */
 router.get('/words', getWords);
 router.get('/examples', getExamples);

--- a/src/routers/router.js
+++ b/src/routers/router.js
@@ -1,6 +1,6 @@
 import express from 'express';
-import { getWords } from '../controllers/words';
-import { getExamples } from '../controllers/examples';
+import { getWords, postWord } from '../controllers/words';
+import { getExamples, postExample } from '../controllers/examples';
 
 const router = express.Router();
 
@@ -58,5 +58,10 @@ const router = express.Router();
  */
 router.get('/words', getWords);
 router.get('/examples', getExamples);
+
+if (process.env.NODE_ENV !== 'production') {
+  router.post('/words', postWord);
+  router.post('/examples', postExample);
+}
 
 export default router;

--- a/tests/__mocks__/documentData.js
+++ b/tests/__mocks__/documentData.js
@@ -22,6 +22,12 @@ const updatedWordSuggestionData = {
   definitions: ['first', 'second'],
 };
 
+const malformedWordData = {
+  worrd: 'newWord',
+  wordClass: '',
+  definitions: [],
+};
+
 const exampleSuggestionData = {
   igbo: 'igbo text',
   english: 'english text',
@@ -42,6 +48,7 @@ export {
   wordSuggestionData,
   malformedWordSuggestionData,
   updatedWordSuggestionData,
+  malformedWordData,
   exampleSuggestionData,
   malformedExampleSuggestionData,
   updatedExampleSuggestionData,

--- a/tests/exampleSuggestions.test.js
+++ b/tests/exampleSuggestions.test.js
@@ -14,7 +14,7 @@ import {
   exampleSuggestionData,
   malformedExampleSuggestionData,
   updatedExampleSuggestionData,
-} from './__mocks__/suggestions';
+} from './__mocks__/documentData';
 import { LONG_TIMEOUT } from './shared/constants';
 import expectUniqSetsOfResponses from './shared/utils';
 

--- a/tests/examples.test.js
+++ b/tests/examples.test.js
@@ -1,12 +1,48 @@
 import chai from 'chai';
-import { isEqual } from 'lodash';
-import { getExamples } from './shared/commands';
+import { isEqual, some } from 'lodash';
+import { createExample, getExamples } from './shared/commands';
 import { LONG_TIMEOUT } from './shared/constants';
 import expectUniqSetsOfResponses from './shared/utils';
+import { exampleSuggestionData, malformedWordSuggestionData } from './__mocks__/documentData';
 
 const { expect } = chai;
 
 describe('MongoDB Examples', () => {
+  describe('/POST mongodb examples', () => {
+    it('should create a new example in the database', (done) => {
+      createExample(exampleSuggestionData)
+        .end((_, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body.id).to.not.equal(undefined);
+          done();
+        });
+    });
+
+    it('should throw an error for malformed new example data', (done) => {
+      createExample(malformedWordSuggestionData)
+        .end((_, res) => {
+          expect(res.status).to.equal(400);
+          expect(res.body.error).to.not.equal(undefined);
+          done();
+        });
+    });
+
+    it('should return newly created example by searching with keyword', (done) => {
+      createExample(exampleSuggestionData)
+        .then((res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body.id).to.not.equal(undefined);
+          getExamples({ keyword: exampleSuggestionData.igbo })
+            .end((_, result) => {
+              expect(res.status).to.equal(200);
+              console.log(result.body);
+              expect(some(result.body, (example) => example.igbo === exampleSuggestionData.igbo)).to.equal(true);
+              done();
+            });
+        });
+    });
+  });
+
   describe('/GET mongodb examples', () => {
     it('should return an example by searching', (done) => {
       getExamples()

--- a/tests/shared/commands.js
+++ b/tests/shared/commands.js
@@ -44,6 +44,20 @@ export const getGenericWord = (id) => (
     .get(`${EDIT_API_ROUTE}/genericWords/${id}`)
 );
 
+export const createWord = (data) => (
+  chai
+    .request(server)
+    .post(`${API_ROUTE}/words`)
+    .send(data)
+);
+
+export const createExample = (data) => (
+  chai
+    .request(server)
+    .post(`${API_ROUTE}/examples`)
+    .send(data)
+);
+
 export const suggestNewWord = (data) => (
   chai
     .request(server)

--- a/tests/wordSuggestions.test.js
+++ b/tests/wordSuggestions.test.js
@@ -14,7 +14,7 @@ import {
   wordSuggestionData,
   malformedWordSuggestionData,
   updatedWordSuggestionData,
-} from './__mocks__/suggestions';
+} from './__mocks__/documentData';
 import { LONG_TIMEOUT } from './shared/constants';
 import expectUniqSetsOfResponses from './shared/utils';
 


### PR DESCRIPTION
Exposes two new routes that allow for a **merger** to create a new `Word` or `Example` document in the database.

Closes #147 