### PR TITLE
Igbo api 93/get words with Id

### DIFF
--- a/src/controllers/exampleSuggestions.js
+++ b/src/controllers/exampleSuggestions.js
@@ -69,9 +69,13 @@ export const getExampleSuggestions = (req, res) => {
 export const getExampleSuggestion = (req, res) => {
   const { id } = req.params;
   return ExampleSuggestion.findById(id)
-    .then((exampleSuggestion) => (
-      res.send(exampleSuggestion)
-    ))
+    .then((exampleSuggestion) => {
+      if (!exampleSuggestion) {
+        res.status(400);
+        return res.send({ error: 'No example suggestion exists with the provided id.' });
+      }
+      return res.send(exampleSuggestion);
+    })
     .catch(() => {
       res.status(400);
       return res.send({ error: 'An error has occurred while returning a single example suggestion' });

--- a/src/controllers/examples.js
+++ b/src/controllers/examples.js
@@ -23,6 +23,23 @@ export const getExamples = async (req, res) => {
   return prepResponse(res, examples, page, sort);
 };
 
+/* Returns an example from MongoDB using an id */
+export const getExample = (req, res) => {
+  const { id } = req.params;
+  return Example.findById(id)
+    .then((example) => {
+      if (!example) {
+        res.status(400);
+        return res.send({ error: 'No example exists with the provided id.' });
+      }
+      return res.send(example);
+    })
+    .catch(() => {
+      res.status(400);
+      return res.send({ error: 'An error has occurred while return a single example.' });
+    });
+};
+
 /* Call the createExample helper function and returns status to client */
 export const postExample = (req, res) => {
   const { body: data } = req;

--- a/src/controllers/genericWords.js
+++ b/src/controllers/genericWords.js
@@ -21,9 +21,13 @@ export const getGenericWords = (req, res) => {
 export const getGenericWord = (req, res) => {
   const { id } = req.params;
   return GenericWord.findById(id)
-    .then((genericWord) => (
-      res.send(genericWord)
-    ))
+    .then((genericWord) => {
+      if (!genericWord) {
+        res.status(400);
+        return res.send({ error: 'No genericWord exists with the provided id.' });
+      }
+      return res.send(genericWord);
+    })
     .catch(() => {
       res.status(400);
       return res.send({ error: 'An error has occurred while return a single word suggestion' });

--- a/src/controllers/wordSuggestions.js
+++ b/src/controllers/wordSuggestions.js
@@ -72,9 +72,13 @@ export const getWordSuggestions = (req, res) => {
 export const getWordSuggestion = (req, res) => {
   const { id } = req.params;
   return WordSuggestion.findById(id)
-    .then((wordSuggestion) => (
-      res.send(wordSuggestion)
-    ))
+    .then((wordSuggestion) => {
+      if (!wordSuggestion) {
+        res.status(400);
+        return res.send({ error: 'No word suggestion exists with the provided id.' });
+      }
+      return res.send(wordSuggestion);
+    })
     .catch(() => {
       res.status(400);
       return res.send({ error: 'An error has occurred while returning a single word suggestion' });

--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -62,6 +62,23 @@ export const getWords = async (req, res) => {
   return prepResponse(res, words, page, sort);
 };
 
+/* Returns a word from MongoDB using an id */
+export const getWord = (req, res) => {
+  const { id } = req.params;
+  return Word.findById(id)
+    .then((word) => {
+      if (!word) {
+        res.status(400);
+        return res.send({ error: 'No word exists with the provided id.' });
+      }
+      return res.send(word);
+    })
+    .catch(() => {
+      res.status(400);
+      return res.send({ error: 'An error has occurred while returning a single word.' });
+    });
+};
+
 /* Creates Word documents in MongoDB database */
 export const createWord = async (data) => {
   const {

--- a/src/routers/router.js
+++ b/src/routers/router.js
@@ -77,6 +77,24 @@ const router = express.Router();
  *                id:
  *                type: string
  *
+ * /words/{wordId}:
+ *   get:
+ *     description: Returns a single Word object from the database
+ *     tags:
+ *      - development
+ *     consumes:
+ *       - application/json
+ *     parameters:
+ *        - in: path
+ *          name: wordId
+ *          required: true
+ *          schema:
+ *            type: string
+ *          description: the word id
+ *     responses:
+ *      200:
+ *         description: OK
+ *
  * /examples:
  *   get:
  *     description: Get examples in dictionary
@@ -123,6 +141,24 @@ const router = express.Router();
  *               type: array
  *               items:
  *                 type: string
+ *
+ * /examples/{exampleId}:
+ *   get:
+ *     description: Returns a single Example object from the database
+ *     tags:
+ *      - development
+ *     consumes:
+ *       - application/json
+ *     parameters:
+ *        - in: path
+ *          name: exampleId
+ *          required: true
+ *          schema:
+ *            type: string
+ *          description: the example id
+ *     responses:
+ *      200:
+ *         description: OK
  */
 router.get('/words', getWords);
 router.get('/words/:id', getWord);

--- a/src/routers/router.js
+++ b/src/routers/router.js
@@ -1,6 +1,16 @@
 import express from 'express';
-import { getWords, putWord, postWord } from '../controllers/words';
-import { getExamples, putExample, postExample } from '../controllers/examples';
+import {
+  getWords,
+  getWord,
+  putWord,
+  postWord,
+} from '../controllers/words';
+import {
+  getExamples,
+  getExample,
+  putExample,
+  postExample,
+} from '../controllers/examples';
 
 const router = express.Router();
 
@@ -115,7 +125,9 @@ const router = express.Router();
  *                 type: string
  */
 router.get('/words', getWords);
+router.get('/words/:id', getWord);
 router.get('/examples', getExamples);
+router.get('/examples/:id', getExample);
 
 if (process.env.NODE_ENV !== 'production') {
   router.post('/words', postWord);

--- a/tests/api-mongo.test.js
+++ b/tests/api-mongo.test.js
@@ -16,6 +16,7 @@ import {
   EXAMPLE_KEYS,
   EXCLUDE_KEYS,
   INVALID_ID,
+  NONEXISTENT_ID,
 } from './shared/constants';
 import {
   wordData,
@@ -159,8 +160,8 @@ describe('MongoDB Words', function () {
 
     it('should return an error for incorrect word id', (done) => {
       getWords()
-        .then((res) => {
-          getWord(res.body[0].id.replace(/.$/, '0'))
+        .then(() => {
+          getWord(NONEXISTENT_ID)
             .end((_, result) => {
               expect(result.status).to.equal(400);
               expect(result.error).to.not.equal(undefined);

--- a/tests/exampleSuggestions.test.js
+++ b/tests/exampleSuggestions.test.js
@@ -15,22 +15,10 @@ import {
   malformedExampleSuggestionData,
   updatedExampleSuggestionData,
 } from './__mocks__/documentData';
-import { LONG_TIMEOUT } from './shared/constants';
+import { LONG_TIMEOUT, EXAMPLE_SUGGESTION_KEYS, INVALID_ID } from './shared/constants';
 import { expectUniqSetsOfResponses, expectArrayIsInOrder } from './shared/utils';
 
 const { expect } = chai;
-
-const EXAMPLE_SUGGESTION_KEYS = [
-  'igbo',
-  'english',
-  'associatedWords',
-  'details',
-  'approvals',
-  'denials',
-  'updatedOn',
-  'merged',
-  'id',
-];
 
 describe('MongoDB Example Suggestions', () => {
   describe('/POST mongodb exampleSuggestions', () => {
@@ -95,7 +83,7 @@ describe('MongoDB Example Suggestions', () => {
     });
 
     it('should return an error because document doesn\'t exist', (done) => {
-      getExampleSuggestion('fdsafdsad')
+      getExampleSuggestion(INVALID_ID)
         .end((_, res) => {
           expect(res.status).to.equal(400);
           expect(res.body.error).to.not.equal(undefined);

--- a/tests/examples.test.js
+++ b/tests/examples.test.js
@@ -1,7 +1,12 @@
 import chai from 'chai';
 import { isEqual, forIn, some } from 'lodash';
-import { createExample, getExamples, updateExample } from './shared/commands';
-import { LONG_TIMEOUT } from './shared/constants';
+import {
+  createExample,
+  getExamples,
+  getExample,
+  updateExample,
+} from './shared/commands';
+import { LONG_TIMEOUT, EXAMPLE_KEYS, INVALID_ID } from './shared/constants';
 import { expectUniqSetsOfResponses, expectArrayIsInOrder } from './shared/utils';
 import {
   exampleData,
@@ -62,11 +67,6 @@ describe('MongoDB Examples', () => {
             });
         });
     });
-
-    it.skip('should return an error because document doesn\'t exist', (done) => {
-      // TODO: complete this test when getting examples by ids is implemented
-      done();
-    });
   });
 
   describe('/GET mongodb examples', () => {
@@ -75,6 +75,40 @@ describe('MongoDB Examples', () => {
         .end((_, res) => {
           expect(res.status).to.equal(200);
           expect(res.body).to.have.lengthOf.at.most(10);
+          done();
+        });
+    });
+
+    it('should return one word', (done) => {
+      getExamples()
+        .then((res) => {
+          getExample(res.body[0].id)
+            .end((_, result) => {
+              expect(result.status).to.equal(200);
+              expect(result.body).to.be.an('object');
+              expect(result.body).to.have.all.keys(EXAMPLE_KEYS);
+              done();
+            });
+        });
+    });
+
+    it('should return an error for incorrect word id', (done) => {
+      getExamples()
+        .then((res) => {
+          getExample(res.body[0].id.replace(/....$/, 'fff1'))
+            .end((_, result) => {
+              expect(result.status).to.equal(400);
+              expect(result.error).to.not.equal(undefined);
+              done();
+            });
+        });
+    });
+
+    it('should return an error because document doesn\'t exist', (done) => {
+      getExample(INVALID_ID)
+        .end((_, res) => {
+          expect(res.status).to.equal(400);
+          expect(res.body.error).to.not.equal(undefined);
           done();
         });
     });

--- a/tests/examples.test.js
+++ b/tests/examples.test.js
@@ -6,7 +6,12 @@ import {
   getExample,
   updateExample,
 } from './shared/commands';
-import { LONG_TIMEOUT, EXAMPLE_KEYS, INVALID_ID } from './shared/constants';
+import {
+  LONG_TIMEOUT,
+  EXAMPLE_KEYS,
+  INVALID_ID,
+  NONEXISTENT_ID,
+} from './shared/constants';
 import { expectUniqSetsOfResponses, expectArrayIsInOrder } from './shared/utils';
 import {
   exampleData,
@@ -94,8 +99,8 @@ describe('MongoDB Examples', () => {
 
     it('should return an error for incorrect word id', (done) => {
       getExamples()
-        .then((res) => {
-          getExample(res.body[0].id.replace(/....$/, 'fff1'))
+        .then(() => {
+          getExample(NONEXISTENT_ID)
             .end((_, result) => {
               expect(result.status).to.equal(400);
               expect(result.error).to.not.equal(undefined);

--- a/tests/genericWords.test.js
+++ b/tests/genericWords.test.js
@@ -8,7 +8,12 @@ import {
   getGenericWords,
   getGenericWord,
 } from './shared/commands';
-import { LONG_TIMEOUT, GENERIC_WORD_KEYS, INVALID_ID } from './shared/constants';
+import {
+  LONG_TIMEOUT,
+  GENERIC_WORD_KEYS,
+  INVALID_ID,
+  NONEXISTENT_ID,
+} from './shared/constants';
 import { expectUniqSetsOfResponses, expectArrayIsInOrder } from './shared/utils';
 
 const { expect } = chai;
@@ -63,8 +68,8 @@ describe('MongoDB Generic Words', () => {
 
     it('should return an error for incorrect word id', (done) => {
       getGenericWords()
-        .then((res) => {
-          getGenericWord(res.body[0].id.replace(/....$/, 'fff1'))
+        .then(() => {
+          getGenericWord(NONEXISTENT_ID)
             .end((_, result) => {
               expect(result.status).to.equal(400);
               expect(result.error).to.not.equal(undefined);

--- a/tests/genericWords.test.js
+++ b/tests/genericWords.test.js
@@ -8,23 +8,10 @@ import {
   getGenericWords,
   getGenericWord,
 } from './shared/commands';
-import { LONG_TIMEOUT } from './shared/constants';
+import { LONG_TIMEOUT, GENERIC_WORD_KEYS, INVALID_ID } from './shared/constants';
 import { expectUniqSetsOfResponses, expectArrayIsInOrder } from './shared/utils';
 
 const { expect } = chai;
-
-const GENERIC_WORD_KEYS = [
-  'word',
-  'wordClass',
-  'definitions',
-  'variations',
-  'details',
-  'approvals',
-  'denials',
-  'updatedOn',
-  'merged',
-  'id',
-];
 
 describe('MongoDB Generic Words', () => {
   before(function (done) {
@@ -71,6 +58,27 @@ describe('MongoDB Generic Words', () => {
               expect(isEqual(result.body, firstGenericWord)).to.equal(true);
               done();
             });
+        });
+    });
+
+    it('should return an error for incorrect word id', (done) => {
+      getGenericWords()
+        .then((res) => {
+          getGenericWord(res.body[0].id.replace(/....$/, 'fff1'))
+            .end((_, result) => {
+              expect(result.status).to.equal(400);
+              expect(result.error).to.not.equal(undefined);
+              done();
+            });
+        });
+    });
+
+    it('should return an error because document doesn\'t exist', (done) => {
+      getGenericWord(INVALID_ID)
+        .end((_, res) => {
+          expect(res.status).to.equal(400);
+          expect(res.body.error).to.not.equal(undefined);
+          done();
         });
     });
 

--- a/tests/shared/commands.js
+++ b/tests/shared/commands.js
@@ -108,6 +108,18 @@ export const getWords = (query = {}) => (
     .query(query)
 );
 
+export const getWord = (id) => (
+  chai
+    .request(server)
+    .get(`${API_ROUTE}/words/${id}`)
+);
+
+export const getExample = (id) => (
+  chai
+    .request(server)
+    .get(`${API_ROUTE}/examples/${id}`)
+);
+
 /* Searches for examples using the data in MongoDB */
 export const getExamples = (query = {}) => (
   chai

--- a/tests/shared/constants.js
+++ b/tests/shared/constants.js
@@ -2,3 +2,44 @@ export const LONG_TIMEOUT = 30000;
 export const EDIT_API_ROUTE = '/api/v1/edit';
 export const API_ROUTE = '/api/v1';
 export const TEST_ROUTE = '/api/v1/test';
+
+export const WORD_KEYS = ['variations', 'definitions', 'stems', 'examples', 'id', 'normalized', 'word', 'wordClass'];
+export const EXAMPLE_KEYS = ['igbo', 'english', 'associatedWords', 'id'];
+export const EXAMPLE_SUGGESTION_KEYS = [
+  'igbo',
+  'english',
+  'associatedWords',
+  'details',
+  'approvals',
+  'denials',
+  'updatedOn',
+  'merged',
+  'id',
+];
+export const GENERIC_WORD_KEYS = [
+  'word',
+  'wordClass',
+  'definitions',
+  'variations',
+  'details',
+  'approvals',
+  'denials',
+  'updatedOn',
+  'merged',
+  'id',
+];
+export const WORD_SUGGESTION_KEYS = [
+  'originalWordId',
+  'word',
+  'wordClass',
+  'definitions',
+  'variations',
+  'details',
+  'approvals',
+  'denials',
+  'updatedOn',
+  'merged',
+  'id',
+];
+export const EXCLUDE_KEYS = ['__v', '_id'];
+export const INVALID_ID = 'fdsafdsad';

--- a/tests/shared/constants.js
+++ b/tests/shared/constants.js
@@ -1,3 +1,5 @@
+import mongoose from 'mongoose';
+
 export const LONG_TIMEOUT = 30000;
 export const EDIT_API_ROUTE = '/api/v1/edit';
 export const API_ROUTE = '/api/v1';
@@ -43,3 +45,4 @@ export const WORD_SUGGESTION_KEYS = [
 ];
 export const EXCLUDE_KEYS = ['__v', '_id'];
 export const INVALID_ID = 'fdsafdsad';
+export const NONEXISTENT_ID = new mongoose.Types.ObjectId();

--- a/tests/wordSuggestions.test.js
+++ b/tests/wordSuggestions.test.js
@@ -15,24 +15,10 @@ import {
   malformedWordSuggestionData,
   updatedWordSuggestionData,
 } from './__mocks__/documentData';
-import { LONG_TIMEOUT } from './shared/constants';
+import { LONG_TIMEOUT, WORD_SUGGESTION_KEYS, INVALID_ID } from './shared/constants';
 import { expectUniqSetsOfResponses, expectArrayIsInOrder } from './shared/utils';
 
 const { expect } = chai;
-
-const WORD_SUGGESTION_KEYS = [
-  'originalWordId',
-  'word',
-  'wordClass',
-  'definitions',
-  'variations',
-  'details',
-  'approvals',
-  'denials',
-  'updatedOn',
-  'merged',
-  'id',
-];
 
 describe('MongoDB Word Suggestions', () => {
   describe('/POST mongodb wordSuggestions', () => {
@@ -94,7 +80,7 @@ describe('MongoDB Word Suggestions', () => {
     });
 
     it('should return an error because document doesn\'t exist', (done) => {
-      getWordSuggestion('fdsafdsad')
+      getWordSuggestion(INVALID_ID)
         .end((_, res) => {
           expect(res.status).to.equal(400);
           expect(res.body.error).to.not.equal(undefined);


### PR DESCRIPTION
Consumers of the API will be able to grab a single word or example by using the following routes:

`api/v1/words/:id`
`api/v1/examples/:id`

Closes #93 