### PR TITLE
Igbo api 153/put generic words

### DIFF
--- a/src/controllers/genericWords.js
+++ b/src/controllers/genericWords.js
@@ -1,8 +1,40 @@
-import { forIn } from 'lodash';
+import {
+  assign,
+  every,
+  has,
+  partial,
+  forIn,
+} from 'lodash';
 import GenericWord from '../models/GenericWord';
 import testGenericWordsDictionary from '../../tests/__mocks__/genericWords.mock.json';
 import genericWordsDictionary from '../dictionaries/ig-en/ig-en_normalized_expanded.json';
 import { prepResponse, handleQueries } from './utils';
+
+const REQUIRE_KEYS = ['word', 'wordClass', 'definitions'];
+
+/* Updates an existing WordSuggestion object */
+export const putGenericWord = (req, res) => {
+  const { body: data, params: { id } } = req;
+  if (!every(REQUIRE_KEYS, partial(has, data))) {
+    res.status(400);
+    return res.send({ error: 'Required information is missing, double check your provided data' });
+  }
+
+  return GenericWord.findById(id)
+    .then(async (genericWord) => {
+      if (!genericWord) {
+        res.status(400);
+        return res.send({ error: 'Generic word doesn\'t exist' });
+      }
+      const updatedGenericWord = assign(genericWord, data);
+      return res.send(await updatedGenericWord.save());
+    })
+    .catch((err) => {
+      console.log(err);
+      res.status(400);
+      return res.send({ error: 'An error has occurred while updating, double check your provided data' });
+    });
+};
 
 /* Returns all existing GenericWord objects */
 export const getGenericWords = (req, res) => {

--- a/src/routers/editRouter.js
+++ b/src/routers/editRouter.js
@@ -11,7 +11,12 @@ import {
   postExampleSuggestion,
   putExampleSuggestion,
 } from '../controllers/exampleSuggestions';
-import { getGenericWords, createGenericWords, getGenericWord } from '../controllers/genericWords';
+import {
+  getGenericWords,
+  createGenericWords,
+  putGenericWord,
+  getGenericWord,
+} from '../controllers/genericWords';
 
 const editRouter = express.Router();
 
@@ -291,8 +296,50 @@ if (process.env.NODE_ENV !== 'production') { // TODO: remove this guard rail whe
  *     responses:
  *      200:
  *         description: OK
+ *
+ *   put:
+ *      description: Updates an existing GenericWord document
+ *      tags:
+ *       - development
+ *      consumes:
+ *        - application/json
+ *      parameters:
+ *       - in: path
+ *         name: genericWordId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: the genericWord id
+ *       - in: body
+ *         name: body
+ *         description: The updated generic word data
+ *         schema:
+ *           type: object
+ *           properties:
+ *             id:
+ *               type: string
+ *             word:
+ *               type: string
+ *             wordClass:
+ *               type: string
+ *             definitions:
+ *               type: array
+ *               items:
+ *                 type: string
+ *             variations:
+ *               type: array
+ *               items:
+ *                 type: string
+ *      responses:
+ *        200:
+ *         description: OK
+ *         content:
+ *          application/json:
+ *            schema:
+ *              type: object
  */
   editRouter.post('/genericWords', createGenericWords);
+  editRouter.put('/genericWords/:id', putGenericWord);
   editRouter.get('/genericWords', getGenericWords);
   editRouter.get('/genericWords/:id', getGenericWord);
 }

--- a/src/routers/router.js
+++ b/src/routers/router.js
@@ -81,7 +81,7 @@ const router = express.Router();
  *   get:
  *     description: Returns a single Word object from the database
  *     tags:
- *      - development
+ *      - production
  *     consumes:
  *       - application/json
  *     parameters:
@@ -146,7 +146,7 @@ const router = express.Router();
  *   get:
  *     description: Returns a single Example object from the database
  *     tags:
- *      - development
+ *      - production
  *     consumes:
  *       - application/json
  *     parameters:

--- a/tests/__mocks__/documentData.js
+++ b/tests/__mocks__/documentData.js
@@ -67,6 +67,27 @@ const updatedExampleData = {
   associatedWords: ['5f864d7401203866b6546dd3'],
 };
 
+const genericWordData = {
+  word: 'genericWord',
+  wordClass: 'noun',
+  definitions: [],
+};
+
+const malformedGenericWordData = {
+  word: 'newGenericWord',
+  wordClass: '',
+  definitions: [],
+  approvals: 'car',
+};
+
+const updatedGenericWordData = {
+  word: 'newWord',
+  wordClass: 'verb',
+  definitions: ['required'],
+  approvals: 2,
+  denials: 1,
+};
+
 export {
   wordSuggestionData,
   malformedWordSuggestionData,
@@ -79,4 +100,7 @@ export {
   updatedExampleSuggestionData,
   exampleData,
   updatedExampleData,
+  genericWordData,
+  malformedGenericWordData,
+  updatedGenericWordData,
 };

--- a/tests/shared/commands.js
+++ b/tests/shared/commands.js
@@ -86,6 +86,13 @@ export const updateExampleSuggestion = (id, data) => (
     .send(data)
 );
 
+export const updateGenericWord = (id, data) => (
+  chai
+    .request(server)
+    .put(`${EDIT_API_ROUTE}/genericWords/${id}`)
+    .send(data)
+);
+
 export const updateWord = (id, data) => (
   chai
     .request(server)


### PR DESCRIPTION
When a PUT request is made at the `api/v1/edit/genericWords/:id` endpoint, a `GenericWord` document can be updated

Closes #153 