### PR TITLE
Merge Words and Examples

### DIFF
--- a/src/controllers/exampleSuggestions.js
+++ b/src/controllers/exampleSuggestions.js
@@ -65,10 +65,14 @@ export const getExampleSuggestions = (req, res) => {
     });
 };
 
+export const findExampleSuggestionById = (id) => (
+  ExampleSuggestion.findById(id)
+);
+
 /* Returns a single ExampleSuggestion by using an id */
 export const getExampleSuggestion = (req, res) => {
   const { id } = req.params;
-  return ExampleSuggestion.findById(id)
+  return findExampleSuggestionById(id)
     .then((exampleSuggestion) => {
       if (!exampleSuggestion) {
         res.status(400);

--- a/src/controllers/genericWords.js
+++ b/src/controllers/genericWords.js
@@ -49,10 +49,14 @@ export const getGenericWords = (req, res) => {
     });
 };
 
+export const findGenericWordById = (id) => (
+  GenericWord.findById(id)
+);
+
 /* Returns a single WordSuggestion by using an id */
 export const getGenericWord = (req, res) => {
   const { id } = req.params;
-  return GenericWord.findById(id)
+  return findGenericWordById(id)
     .then((genericWord) => {
       if (!genericWord) {
         res.status(400);

--- a/src/controllers/utils/index.js
+++ b/src/controllers/utils/index.js
@@ -1,5 +1,5 @@
 import stringSimilarity from 'string-similarity';
-import { orderBy } from 'lodash';
+import { assign, orderBy } from 'lodash';
 import removePrefix from '../../shared/utils/removePrefix';
 import createRegExp from '../../shared/utils/createRegExp';
 
@@ -76,4 +76,10 @@ export const handleQueries = (query = {}) => {
     page,
     sort,
   };
+};
+
+/* Updates a document's merge property with a document id */
+export const updateDocumentMerge = (doc, id) => {
+  const updatedDoc = assign(doc, { merged: id });
+  updatedDoc.save();
 };

--- a/src/controllers/wordSuggestions.js
+++ b/src/controllers/wordSuggestions.js
@@ -30,6 +30,10 @@ export const postWordSuggestion = (req, res) => {
     });
 };
 
+export const findWordSuggestionById = (id) => (
+  WordSuggestion.findById(id)
+);
+
 /* Updates an existing WordSuggestion object */
 export const putWordSuggestion = (req, res) => {
   const { body: data, params: { id } } = req;
@@ -38,7 +42,7 @@ export const putWordSuggestion = (req, res) => {
     return res.send({ error: 'Required information is missing, double check your provided data' });
   }
 
-  return WordSuggestion.findById(id)
+  return findWordSuggestionById(id)
     .then(async (wordSuggestion) => {
       if (!wordSuggestion) {
         res.status(400);

--- a/src/models/ExampleSuggestion.js
+++ b/src/models/ExampleSuggestion.js
@@ -11,7 +11,7 @@ const exampleSuggestionSchema = new Schema({
   approvals: { type: Number, default: 0 },
   denials: { type: Number, default: 0 },
   updatedOn: { type: Date, default: Date.now() },
-  merged: { type: Boolean, default: false },
+  merged: { type: Types.ObjectId, ref: 'Example', default: null },
 });
 
 toJSONPlugin(exampleSuggestionSchema);

--- a/src/models/GenericWord.js
+++ b/src/models/GenericWord.js
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose';
 import { toJSONPlugin } from './plugins';
 
-const { Schema } = mongoose;
+const { Schema, Types } = mongoose;
 const genericWordSchema = new Schema({
   word: { type: String, required: true },
   wordClass: { type: String, default: '' },
@@ -14,7 +14,7 @@ const genericWordSchema = new Schema({
   approvals: { type: Number, default: 0 },
   denials: { type: Number, default: 0 },
   updatedOn: { type: Date, default: Date.now() },
-  merged: { type: Boolean, default: false },
+  merged: { type: Types.ObjectId, ref: 'Word', default: null },
 });
 
 toJSONPlugin(genericWordSchema);

--- a/src/models/WordSuggestion.js
+++ b/src/models/WordSuggestion.js
@@ -15,7 +15,7 @@ const wordSuggestionSchema = new Schema({
   approvals: { type: Number, default: 0 },
   denials: { type: Number, default: 0 },
   updatedOn: { type: Date, default: Date.now() },
-  merged: { type: Boolean, default: false },
+  merged: { type: Types.ObjectId, ref: 'Word', default: null },
 });
 
 toJSONPlugin(wordSuggestionSchema);

--- a/tests/__mocks__/documentData.js
+++ b/tests/__mocks__/documentData.js
@@ -22,12 +22,6 @@ const updatedWordSuggestionData = {
   definitions: ['first', 'second'],
 };
 
-const wordData = {
-  word: 'word',
-  wordClass: 'noun',
-  definitions: [],
-};
-
 const malformedWordData = {
   worrd: 'newWord',
   wordClass: '',
@@ -92,7 +86,6 @@ export {
   wordSuggestionData,
   malformedWordSuggestionData,
   updatedWordSuggestionData,
-  wordData,
   malformedWordData,
   updatedWordData,
   exampleSuggestionData,


### PR DESCRIPTION
The POST routes for `Words` and `Examples` are now updated requiring the data that provided needs to be an either pre-existing `WordSuggestion` or `ExampleSuggestion` document