### PR TITLE
Change schemas for suggestions and generic documents

### DIFF
--- a/src/controllers/genericWords.js
+++ b/src/controllers/genericWords.js
@@ -3,7 +3,7 @@ import {
   every,
   has,
   partial,
-  forIn,
+  map,
 } from 'lodash';
 import GenericWord from '../models/GenericWord';
 import testGenericWordsDictionary from '../../tests/__mocks__/genericWords.mock.json';
@@ -72,14 +72,13 @@ export const getGenericWord = (req, res) => {
 
 /* Populates the MongoDB database with GenericWords */
 export const createGenericWords = (_, res) => {
-  const genericWordsPromises = [];
   const dictionary = process.env.NODE_ENV === 'test' ? testGenericWordsDictionary : genericWordsDictionary;
-  forIn(dictionary, (value, key) => {
-    const newGenericWords = new GenericWord({
+  const genericWordsPromises = map(dictionary, (value, key) => {
+    const newGenericWord = new GenericWord({
       word: key,
       definitions: value,
     });
-    genericWordsPromises.push(newGenericWords.save());
+    return newGenericWord.save();
   });
 
   Promise.all(genericWordsPromises)

--- a/src/models/ExampleSuggestion.js
+++ b/src/models/ExampleSuggestion.js
@@ -8,8 +8,8 @@ const exampleSuggestionSchema = new Schema({
   english: { type: String, default: '' },
   associatedWords: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
   details: { type: String, default: '' },
-  approvals: { type: Number, default: 0 },
-  denials: { type: Number, default: 0 },
+  approvals: { type: [{ type: String }], default: [] },
+  denials: { type: [{ type: String }], default: [] },
   updatedOn: { type: Date, default: Date.now() },
   merged: { type: Types.ObjectId, ref: 'Example', default: null },
 });

--- a/src/models/GenericWord.js
+++ b/src/models/GenericWord.js
@@ -11,8 +11,8 @@ const genericWordSchema = new Schema({
   },
   variations: { type: [{ type: String }], default: [] },
   details: { type: String, default: '' },
-  approvals: { type: Number, default: 0 },
-  denials: { type: Number, default: 0 },
+  approvals: { type: [{ type: String }], default: [] },
+  denials: { type: [{ type: String }], default: [] },
   updatedOn: { type: Date, default: Date.now() },
   merged: { type: Types.ObjectId, ref: 'Word', default: null },
 });

--- a/src/models/WordSuggestion.js
+++ b/src/models/WordSuggestion.js
@@ -12,8 +12,8 @@ const wordSuggestionSchema = new Schema({
   },
   variations: { type: [{ type: String }], default: [] },
   details: { type: String, default: '' },
-  approvals: { type: Number, default: 0 },
-  denials: { type: Number, default: 0 },
+  approvals: { type: [{ type: String }], default: [] },
+  denials: { type: [{ type: String }], default: [] },
   updatedOn: { type: Date, default: Date.now() },
   merged: { type: Types.ObjectId, ref: 'Word', default: null },
 });


### PR DESCRIPTION
This updates the shape of the `WordSuggestion`, `ExampleSuggestion`, and `GenericWord` collection documents so that it's easier to keep track of updated data.

Also, `ig-en_normalized_expanded.json` was accidentally overwritten in a past PR. The correct data is restored.

Closes #149 