### PR TITLE
Igbo api 178/sort suggestions and generic documents

### DIFF
--- a/src/controllers/exampleSuggestions.js
+++ b/src/controllers/exampleSuggestions.js
@@ -55,7 +55,9 @@ export const putExampleSuggestion = (req, res) => {
 /* Returns all existing ExampleSuggestion objects */
 export const getExampleSuggestions = (req, res) => {
   const { regexKeyword, page, sort } = handleQueries(req.query);
-  ExampleSuggestion.find({ $or: [{ igbo: regexKeyword }, { english: regexKeyword }] })
+  return ExampleSuggestion
+    .find({ $or: [{ igbo: regexKeyword }, { english: regexKeyword }] })
+    .sort({ approvals: 'desc' })
     .then((exampleSuggestions) => (
       prepResponse(res, exampleSuggestions, page, sort)
     ))

--- a/src/controllers/genericWords.js
+++ b/src/controllers/genericWords.js
@@ -29,8 +29,7 @@ export const putGenericWord = (req, res) => {
       const updatedGenericWord = assign(genericWord, data);
       return res.send(await updatedGenericWord.save());
     })
-    .catch((err) => {
-      console.log(err);
+    .catch(() => {
       res.status(400);
       return res.send({ error: 'An error has occurred while updating, double check your provided data' });
     });
@@ -39,7 +38,9 @@ export const putGenericWord = (req, res) => {
 /* Returns all existing GenericWord objects */
 export const getGenericWords = (req, res) => {
   const { regexKeyword, page, sort } = handleQueries(req.query);
-  return GenericWord.find({ word: regexKeyword })
+  return GenericWord
+    .find({ word: regexKeyword })
+    .sort({ approvals: 'desc' })
     .then((genericWords) => (
       prepResponse(res, genericWords, page, sort)
     ))

--- a/src/controllers/wordSuggestions.js
+++ b/src/controllers/wordSuggestions.js
@@ -60,7 +60,9 @@ export const putWordSuggestion = (req, res) => {
 /* Returns all existing WordSuggestion objects */
 export const getWordSuggestions = (req, res) => {
   const { regexKeyword, page, sort } = handleQueries(req.query);
-  WordSuggestion.find({ word: regexKeyword })
+  WordSuggestion
+    .find({ word: regexKeyword })
+    .sort({ approvals: 'desc' })
     .then((wordSuggestions) => (
       prepResponse(res, wordSuggestions, page, sort)
     ))

--- a/tests/__mocks__/documentData.js
+++ b/tests/__mocks__/documentData.js
@@ -10,6 +10,14 @@ const wordSuggestionData = {
   definitions: ['first'],
 };
 
+const wordSuggestionApprovedData = {
+  originalWordId: wordId,
+  word: 'word',
+  wordClass: 'wordClass',
+  definitions: ['first'],
+  approvals: ['first user', 'second user'],
+};
+
 const malformedWordSuggestionData = {
   word: 'word',
   wordCllass: 'wordClass',
@@ -37,6 +45,12 @@ const updatedWordData = {
 const exampleSuggestionData = {
   igbo: 'igbo text',
   english: 'english text',
+};
+
+const exampleSuggestionApprovedData = {
+  igbo: 'igbo text',
+  english: 'english text',
+  approvals: ['first user', 'second user'],
 };
 
 const malformedExampleSuggestionData = {
@@ -67,6 +81,13 @@ const genericWordData = {
   definitions: [],
 };
 
+const genericWordApprovedData = {
+  word: 'genericWord',
+  wordClass: 'noun',
+  definitions: [],
+  approvals: ['first user', 'second user'],
+};
+
 const malformedGenericWordData = {
   word: 'newGenericWord',
   wordClass: '',
@@ -84,16 +105,19 @@ const updatedGenericWordData = {
 
 export {
   wordSuggestionData,
+  wordSuggestionApprovedData,
   malformedWordSuggestionData,
   updatedWordSuggestionData,
   malformedWordData,
   updatedWordData,
   exampleSuggestionData,
+  exampleSuggestionApprovedData,
   malformedExampleSuggestionData,
   updatedExampleSuggestionData,
   exampleData,
   updatedExampleData,
   genericWordData,
+  genericWordApprovedData,
   malformedGenericWordData,
   updatedGenericWordData,
 };

--- a/tests/api-mongo.test.js
+++ b/tests/api-mongo.test.js
@@ -440,7 +440,7 @@ describe('MongoDB Words', function () {
         });
     });
 
-    it('should return a ascending sorted list of words with sort query', (done) => {
+    it('should return an ascending sorted list of words with sort query', (done) => {
       const key = 'definitions';
       const direction = 'asc';
       getWords({ sort: `["${key}": "${direction}"]` })

--- a/tests/exampleSuggestions.test.js
+++ b/tests/exampleSuggestions.test.js
@@ -12,6 +12,7 @@ import {
 } from './shared/commands';
 import {
   exampleSuggestionData,
+  exampleSuggestionApprovedData,
   malformedExampleSuggestionData,
   updatedExampleSuggestionData,
 } from './__mocks__/documentData';
@@ -142,6 +143,20 @@ describe('MongoDB Example Suggestions', () => {
         });
     });
 
+    it('should be sorted by number of approvals', (done) => {
+      Promise.all([
+        suggestNewExample(exampleSuggestionData),
+        suggestNewExample(exampleSuggestionApprovedData),
+      ]).then(() => {
+        getExampleSuggestions()
+          .end((_, res) => {
+            expect(res.status).to.equal(200);
+            expectArrayIsInOrder(res.body, 'approvals', 'desc');
+            done();
+          });
+      });
+    });
+
     it('should return one example suggestion', (done) => {
       suggestNewExample(exampleSuggestionData)
         .then((res) => {
@@ -200,7 +215,7 @@ describe('MongoDB Example Suggestions', () => {
         });
     });
 
-    it('should return a ascending sorted list of example suggestions with sort query', (done) => {
+    it('should return an ascending sorted list of example suggestions with sort query', (done) => {
       const key = 'definitions';
       const direction = 'asc';
       getExampleSuggestions({ sort: `["${key}": "${direction}"]` })

--- a/tests/examples.test.js
+++ b/tests/examples.test.js
@@ -205,7 +205,7 @@ describe('MongoDB Examples', () => {
         });
     });
 
-    it('should return a ascending sorted list of examples with sort query', (done) => {
+    it('should return an ascending sorted list of examples with sort query', (done) => {
       const key = 'english';
       const direction = 'asc';
       getExamples({ sort: `["${key}": "${direction}"]` })

--- a/tests/genericWords.test.js
+++ b/tests/genericWords.test.js
@@ -18,7 +18,7 @@ import {
   NONEXISTENT_ID,
 } from './shared/constants';
 import { expectUniqSetsOfResponses, expectArrayIsInOrder } from './shared/utils';
-import { malformedGenericWordData, updatedGenericWordData } from './__mocks__/documentData';
+import { genericWordApprovedData, malformedGenericWordData, updatedGenericWordData } from './__mocks__/documentData';
 
 const { expect } = chai;
 
@@ -50,7 +50,7 @@ describe('MongoDB Generic Words', () => {
       getGenericWords()
         .then((res) => {
           expect(res.status).to.equal(200);
-          updateGenericWord(res.body.id, malformedGenericWordData)
+          updateGenericWord(res.body[0].id, malformedGenericWordData)
             .end((_, result) => {
               expect(result.status).to.equal(400);
               done();
@@ -102,6 +102,22 @@ describe('MongoDB Generic Words', () => {
             expect(genericWords).to.have.all.keys(GENERIC_WORD_KEYS);
           });
           done();
+        });
+    });
+
+    it('should be sorted by number of approvals', (done) => {
+      getGenericWords()
+        .then((res) => {
+          expect(res.status).to.equal(200);
+          updateGenericWord(res.body[0].id, genericWordApprovedData)
+            .then(() => {
+              getGenericWords()
+                .end((_, result) => {
+                  expect(result.status).to.equal(200);
+                  expectArrayIsInOrder(result.body, 'approvals', 'desc');
+                  done();
+                });
+            });
         });
     });
 
@@ -185,7 +201,7 @@ describe('MongoDB Generic Words', () => {
         });
     });
 
-    it('should return a ascending sorted list of generic words with sort query', (done) => {
+    it('should return an ascending sorted list of generic words with sort query', (done) => {
       const key = 'definitions';
       const direction = 'asc';
       getGenericWords({ sort: `["${key}": "${direction}"]` })

--- a/tests/shared/utils.js
+++ b/tests/shared/utils.js
@@ -21,11 +21,16 @@ const expectUniqSetsOfResponses = (res) => {
 };
 
 const expectArrayIsInOrder = (array, key, direction = 'asc') => {
-  const isOrdered = every(map(array, (item) => item[key]), (value, index) => (
-    index === 0 || direction === 'asc'
-      ? String(array[index - 1] <= String(value))
-      : String(array[index - 1] >= String(value))
-  ));
+  const isOrdered = every(map(array, (item) => item[key]), (value, index) => {
+    if (index === 0) {
+      return true;
+    }
+    return (
+      direction === 'asc'
+        ? String(array[index - 1][key] <= String(value))
+        : String(array[index - 1][key] >= String(value))
+    );
+  });
   expect(isOrdered).to.equal(true);
 };
 

--- a/tests/wordSuggestions.test.js
+++ b/tests/wordSuggestions.test.js
@@ -12,6 +12,7 @@ import {
 } from './shared/commands';
 import {
   wordSuggestionData,
+  wordSuggestionApprovedData,
   malformedWordSuggestionData,
   updatedWordSuggestionData,
 } from './__mocks__/documentData';
@@ -90,7 +91,7 @@ describe('MongoDB Word Suggestions', () => {
   });
 
   describe('/GET mongodb wordSuggestions', () => {
-    it('should return an example by searching', (done) => {
+    it('should return a word suggestion by searching', (done) => {
       const keyword = wordSuggestionData.word;
       suggestNewWord(wordSuggestionData)
         .then(() => {
@@ -105,7 +106,7 @@ describe('MongoDB Word Suggestions', () => {
         });
     });
 
-    it('should return an example by searching', (done) => {
+    it('should return a word suggestion by searching', (done) => {
       const filter = wordSuggestionData.word;
       suggestNewWord(wordSuggestionData)
         .then(() => {
@@ -133,6 +134,20 @@ describe('MongoDB Word Suggestions', () => {
               done();
             });
         });
+    });
+
+    it('should be sorted by number of approvals', (done) => {
+      Promise.all([
+        suggestNewWord(wordSuggestionData),
+        suggestNewWord(wordSuggestionApprovedData),
+      ]).then(() => {
+        getWordSuggestions()
+          .end((_, res) => {
+            expect(res.status).to.equal(200);
+            expectArrayIsInOrder(res.body, 'approvals', 'desc');
+            done();
+          });
+      });
     });
 
     it('should return one word suggestion', (done) => {
@@ -193,7 +208,7 @@ describe('MongoDB Word Suggestions', () => {
         });
     });
 
-    it('should return a ascending sorted list of word suggestions with sort query', (done) => {
+    it('should return an ascending sorted list of word suggestions with sort query', (done) => {
       const key = 'definitions';
       const direction = 'asc';
       getWordSuggestions({ sort: `["${key}": "${direction}"]` })


### PR DESCRIPTION
Responses for `WordSuggestion`, `ExampleSuggestion`, and `GenericWord` documents will first be sorted by the number of approvals they have. This will make it easier to see the most important documents to be reviewed.

Closes #178 