### PR TITLE
Create /DELETE route for Words - resolves ijemmao/igbo_api#131

### DIFF
--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -199,3 +199,22 @@ export const putWord = (req, res) => {
       return res.send({ error: 'An error has occurred while updating the word, double check your provided data.' });
     });
 };
+
+export const deleteWord = (req, res) => {
+  const { params: { id } } = req;
+
+  return Word.findByIdAndDelete(id)
+    .then(async (word) => {
+      if (!word) {
+        res.status(400);
+        return res.send({ error: 'Word doesn\'t exist' });
+      }
+
+      res.status(200);
+      return res.send(word);
+    })
+    .catch(() => {
+      res.status(400);
+      return res.send({ error: 'An error has occurred while deleting the word, double check your provided id.' });
+    });
+};

--- a/src/dictionaries/ig-en/ig-en_1000_common.json
+++ b/src/dictionaries/ig-en/ig-en_1000_common.json
@@ -1,6320 +1,7724 @@
 {
-  "dị ka": [
-    {
-      "wordClass": "",
-      "definitions": ["like"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "m": [
-    {
-      "wordClass": "",
-      "definitions": ["mine"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ya": [
-    {
-      "wordClass": "",
-      "definitions": ["him"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na": [
-    {
-      "wordClass": "",
-      "definitions": ["in"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "enye": [
-    {
-      "wordClass": "",
-      "definitions": ["offer"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "bụ": [
-    {
-      "wordClass": "",
-      "definitions": ["is"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’ihi na": [
-    {
-      "wordClass": "",
-      "definitions": ["for"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ụfọdụ": [
-    {
-      "wordClass": "",
-      "definitions": ["certain"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ma ọ bụrụ na": [
-    {
-      "wordClass": "",
-      "definitions": ["if"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọrụ": [
-    {
-      "wordClass": "",
-      "definitions": ["operate"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ha": [
-    {
-      "wordClass": "",
-      "definitions": ["them"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ịbụ": [
-    {
-      "wordClass": "",
-      "definitions": ["be"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "otu": [
-    {
-      "wordClass": "",
-      "definitions": ["party"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nwere": [
-    {
-      "wordClass": "",
-      "definitions": ["contain"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "a": [
-    {
-      "wordClass": "",
-      "definitions": ["a"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "si": [
-    {
-      "wordClass": "",
-      "definitions": ["out"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "site": [
-    {
-      "wordClass": "",
-      "definitions": ["by"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-ekpo ọkụ": [
-    {
-      "wordClass": "",
-      "definitions": ["warm"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "okwu": [
-    {
-      "wordClass": "",
-      "definitions": ["term"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ma": [
-    {
-      "wordClass": "",
-      "definitions": ["either"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ihe": [
-    {
-      "wordClass": "",
-      "definitions": ["deal"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ị": [
-    {
-      "wordClass": "",
-      "definitions": ["you"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ma ọ bụ": [
-    {
-      "wordClass": "",
-      "definitions": ["nor"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nke": [
-    {
-      "wordClass": "",
-      "definitions": ["which"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-": [
-    {
-      "wordClass": "",
-      "definitions": ["continue"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "anyị": [
-    {
-      "wordClass": "",
-      "definitions": ["our"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ike": [
-    {
-      "wordClass": "",
-      "definitions": ["create"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọzọ": [
-    {
-      "wordClass": "",
-      "definitions": ["else"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ndị": [
-    {
-      "wordClass": "",
-      "definitions": ["those"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "eme": [
-    {
-      "wordClass": "",
-      "definitions": ["done"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "oge": [
-    {
-      "wordClass": "",
-      "definitions": ["period"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ekpe": [
-    {
-      "wordClass": "",
-      "definitions": ["left"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "otú": [
-    {
-      "wordClass": "",
-      "definitions": ["so"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "kwuru": [
-    {
-      "wordClass": "",
-      "definitions": ["spoke"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọ bụla": [
-    {
-      "wordClass": "",
-      "definitions": ["every"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ịgwa": [
-    {
-      "wordClass": "",
-      "definitions": ["tell"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ke": [
-    {
-      "wordClass": "",
-      "definitions": ["does"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "set": [
-    {
-      "wordClass": "",
-      "definitions": ["set"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "atọ": [
-    {
-      "wordClass": "",
-      "definitions": ["third"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "chọrọ": [
-    {
-      "wordClass": "",
-      "definitions": ["require"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ikuku": [
-    {
-      "wordClass": "",
-      "definitions": ["air"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọma": [
-    {
-      "wordClass": "",
-      "definitions": ["well"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "igwu egwu": [
-    {
-      "wordClass": "",
-      "definitions": ["play"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "obere": [
-    {
-      "wordClass": "",
-      "definitions": ["tiny"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "njedebe": [
-    {
-      "wordClass": "",
-      "definitions": ["end"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "tinye": [
-    {
-      "wordClass": "",
-      "definitions": ["add"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’ụlọ": [
-    {
-      "wordClass": "",
-      "definitions": ["home"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-agụ": [
-    {
-      "wordClass": "",
-      "definitions": ["read"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "aka": [
-    {
-      "wordClass": "",
-      "definitions": ["finger"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọdụ ụgbọ mmiri": [
-    {
-      "wordClass": "",
-      "definitions": ["port"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nnukwu": [
-    {
-      "wordClass": "",
-      "definitions": ["huge"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "asụpe": [
-    {
-      "wordClass": "",
-      "definitions": ["spell"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọbụna": [
-    {
-      "wordClass": "",
-      "definitions": ["even"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ala": [
-    {
-      "wordClass": "",
-      "definitions": ["soil"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ebe a": [
-    {
-      "wordClass": "",
-      "definitions": ["here"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ana": [
-    {
-      "wordClass": "",
-      "definitions": ["charge"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "elu": [
-    {
-      "wordClass": "",
-      "definitions": ["up"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "dị": [
-    {
-      "wordClass": "",
-      "definitions": ["such"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-eso": [
-    {
-      "wordClass": "",
-      "definitions": ["follow"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ya mere": [
-    {
-      "wordClass": "",
-      "definitions": ["why"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ịjụ": [
-    {
-      "wordClass": "",
-      "definitions": ["ask"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ndị ikom": [
-    {
-      "wordClass": "",
-      "definitions": ["men"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mgbanwe": [
-    {
-      "wordClass": "",
-      "definitions": ["change"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "wee": [
-    {
-      "wordClass": "",
-      "definitions": ["got"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ìhè": [
-    {
-      "wordClass": "",
-      "definitions": ["light"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ụdị": [
-    {
-      "wordClass": "",
-      "definitions": ["type"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "anya": [
-    {
-      "wordClass": "",
-      "definitions": ["forward"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mkpa": [
-    {
-      "wordClass": "",
-      "definitions": ["need"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ụlọ": [
-    {
-      "wordClass": "",
-      "definitions": ["room"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "foto": [
-    {
-      "wordClass": "",
-      "definitions": ["picture"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-agbalị": [
-    {
-      "wordClass": "",
-      "definitions": ["try"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "anụmanụ": [
-    {
-      "wordClass": "",
-      "definitions": ["animal"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ebe": [
-    {
-      "wordClass": "",
-      "definitions": ["station"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nne": [
-    {
-      "wordClass": "",
-      "definitions": ["mother"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ụwa": [
-    {
-      "wordClass": "",
-      "definitions": ["earth"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nso": [
-    {
-      "wordClass": "",
-      "definitions": ["close"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ewu": [
-    {
-      "wordClass": "",
-      "definitions": ["build"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "onwe": [
-    {
-      "wordClass": "",
-      "definitions": ["self"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nna": [
-    {
-      "wordClass": "",
-      "definitions": ["father"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọhụrụ": [
-    {
-      "wordClass": "",
-      "definitions": ["fresh"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "akụkụ": [
-    {
-      "wordClass": "",
-      "definitions": ["fraction"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nara": [
-    {
-      "wordClass": "",
-      "definitions": ["take"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nweta": [
-    {
-      "wordClass": "",
-      "definitions": ["get"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mere": [
-    {
-      "wordClass": "",
-      "definitions": ["did"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ndụ": [
-    {
-      "wordClass": "",
-      "definitions": ["life"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mgbe": [
-    {
-      "wordClass": "",
-      "definitions": ["ever"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "azụ": [
-    {
-      "wordClass": "",
-      "definitions": ["fish"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "naanị": [
-    {
-      "wordClass": "",
-      "definitions": ["only"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "gburugburu": [
-    {
-      "wordClass": "",
-      "definitions": ["circle"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nwoke": [
-    {
-      "wordClass": "",
-      "definitions": ["man"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "afọ": [
-    {
-      "wordClass": "",
-      "definitions": ["age"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "izi": [
-    {
-      "wordClass": "",
-      "definitions": ["show"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mma": [
-    {
-      "wordClass": "",
-      "definitions": ["fair"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nye": [
-    {
-      "wordClass": "",
-      "definitions": ["provide"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’okpuru": [
-    {
-      "wordClass": "",
-      "definitions": ["under"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "aha": [
-    {
-      "wordClass": "",
-      "definitions": ["noun"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nnọọ": [
-    {
-      "wordClass": "",
-      "definitions": ["quite"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "site na": [
-    {
-      "wordClass": "",
-      "definitions": ["through"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "dị nnọọ": [
-    {
-      "wordClass": "",
-      "definitions": ["just"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ikpe": [
-    {
-      "wordClass": "",
-      "definitions": ["case"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "akwa": [
-    {
-      "wordClass": "",
-      "definitions": ["grand"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "chere": [
-    {
-      "wordClass": "",
-      "definitions": ["felt"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-ekwu": [
-    {
-      "wordClass": "",
-      "definitions": ["say"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "akara": [
-    {
-      "wordClass": "",
-      "definitions": ["score"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "iche": [
-    {
-      "wordClass": "",
-      "definitions": ["range"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "N’aka": [
-    {
-      "wordClass": "",
-      "definitions": ["turn"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "kpatara": [
-    {
-      "wordClass": "",
-      "definitions": ["cause"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ukwuu": [
-    {
-      "wordClass": "",
-      "definitions": ["much"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "pụtara": [
-    {
-      "wordClass": "",
-      "definitions": ["meant"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’ihu": [
-    {
-      "wordClass": "",
-      "definitions": ["front"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nkwaghari": [
-    {
-      "wordClass": "",
-      "definitions": ["move"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nri": [
-    {
-      "wordClass": "",
-      "definitions": ["bread"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nwa": [
-    {
-      "wordClass": "",
-      "definitions": ["baby"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ochie": [
-    {
-      "wordClass": "",
-      "definitions": ["old"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "oke": [
-    {
-      "wordClass": "",
-      "definitions": ["too"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọ": [
-    {
-      "wordClass": "",
-      "definitions": ["she"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "niile": [
-    {
-      "wordClass": "",
-      "definitions": ["all"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’ebe ahụ": [
-    {
-      "wordClass": "",
-      "definitions": ["there"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "iji": [
-    {
-      "wordClass": "",
-      "definitions": ["order"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "gị": [
-    {
-      "wordClass": "",
-      "definitions": ["your"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ụzọ": [
-    {
-      "wordClass": "",
-      "definitions": ["path"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "banyere": [
-    {
-      "wordClass": "",
-      "definitions": ["about"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọtụtụ": [
-    {
-      "wordClass": "",
-      "definitions": ["lot"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mgbe ahụ": [
-    {
-      "wordClass": "",
-      "definitions": ["then"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "dee": [
-    {
-      "wordClass": "",
-      "definitions": ["note"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ga-": [
-    {
-      "wordClass": "",
-      "definitions": ["shall"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ndị a": [
-    {
-      "wordClass": "",
-      "definitions": ["these"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ogologo": [
-    {
-      "wordClass": "",
-      "definitions": ["tall"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "eme ka": [
-    {
-      "wordClass": "",
-      "definitions": ["make"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ịhụ": [
-    {
-      "wordClass": "",
-      "definitions": ["see"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "abụọ": [
-    {
-      "wordClass": "",
-      "definitions": ["double"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ụbọchị": [
-    {
-      "wordClass": "",
-      "definitions": ["day"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "aga": [
-    {
-      "wordClass": "",
-      "definitions": ["go"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "bịa": [
-    {
-      "wordClass": "",
-      "definitions": ["come"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọnụ ọgụgụ": [
-    {
-      "wordClass": "",
-      "definitions": ["figure"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ada": [
-    {
-      "wordClass": "",
-      "definitions": ["fall"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mba": [
-    {
-      "wordClass": "",
-      "definitions": ["nation"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "kacha": [
-    {
-      "wordClass": "",
-      "definitions": ["most"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ndị mmadụ": [
-    {
-      "wordClass": "",
-      "definitions": ["people"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’elu": [
-    {
-      "wordClass": "",
-      "definitions": ["surface"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mara": [
-    {
-      "wordClass": "",
-      "definitions": ["notice"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mmiri": [
-    {
-      "wordClass": "",
-      "definitions": ["liquid"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "karịa": [
-    {
-      "wordClass": "",
-      "definitions": ["than"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "oku": [
-    {
-      "wordClass": "",
-      "definitions": ["call"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mbụ": [
-    {
-      "wordClass": "",
-      "definitions": ["original"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "onye": [
-    {
-      "wordClass": "",
-      "definitions": ["whose"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’akụkụ": [
-    {
-      "wordClass": "",
-      "definitions": ["corner"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "kemgbe": [
-    {
-      "wordClass": "",
-      "definitions": ["been"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ugbu a": [
-    {
-      "wordClass": "",
-      "definitions": ["current"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ịchọta": [
-    {
-      "wordClass": "",
-      "definitions": ["find"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "isi": [
-    {
-      "wordClass": "",
-      "definitions": ["basic"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "eguzo": [
-    {
-      "wordClass": "",
-      "definitions": ["stand"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "peeji nke": [
-    {
-      "wordClass": "",
-      "definitions": ["page"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "kwesịrị": [
-    {
-      "wordClass": "",
-      "definitions": ["should"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "obodo": [
-    {
-      "wordClass": "",
-      "definitions": ["village"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "hụrụ": [
-    {
-      "wordClass": "",
-      "definitions": ["found"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "azịza": [
-    {
-      "wordClass": "",
-      "definitions": ["answer"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ụlọ akwụkwọ": [
-    {
-      "wordClass": "",
-      "definitions": ["school"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-eto": [
-    {
-      "wordClass": "",
-      "definitions": ["grew"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọmụmụ": [
-    {
-      "wordClass": "",
-      "definitions": ["study"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ka": [
-    {
-      "wordClass": "",
-      "definitions": ["let"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ịmụta": [
-    {
-      "wordClass": "",
-      "definitions": ["learn"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "osisi": [
-    {
-      "wordClass": "",
-      "definitions": ["board"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mkpuchi": [
-    {
-      "wordClass": "",
-      "definitions": ["cover"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "anyanwụ": [
-    {
-      "wordClass": "",
-      "definitions": ["sun"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "anọ": [
-    {
-      "wordClass": "",
-      "definitions": ["stay"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’etiti": [
-    {
-      "wordClass": "",
-      "definitions": ["middle"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ikpeazụ": [
-    {
-      "wordClass": "",
-      "definitions": ["final"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ịgafe": [
-    {
-      "wordClass": "",
-      "definitions": ["cross"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ugbo": [
-    {
-      "wordClass": "",
-      "definitions": ["farm"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mmalite": [
-    {
-      "wordClass": "",
-      "definitions": ["start"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "akụkọ": [
-    {
-      "wordClass": "",
-      "definitions": ["story"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ikwo": [
-    {
-      "wordClass": "",
-      "definitions": ["saw"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "osimiri": [
-    {
-      "wordClass": "",
-      "definitions": ["river"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ise": [
-    {
-      "wordClass": "",
-      "definitions": ["five"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "omume": [
-    {
-      "wordClass": "",
-      "definitions": ["practice"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "emela": [
-    {
-      "wordClass": "",
-      "definitions": ["don’t"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "akuko": [
-    {
-      "wordClass": "",
-      "definitions": ["press"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "abalị": [
-    {
-      "wordClass": "",
-      "definitions": ["night"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’ezie": [
-    {
-      "wordClass": "",
-      "definitions": ["real"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ole na ole": [
-    {
-      "wordClass": "",
-      "definitions": ["few"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ugwu": [
-    {
-      "wordClass": "",
-      "definitions": ["hill"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "akwụkwọ": [
-    {
-      "wordClass": "",
-      "definitions": ["sheet"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ebu": [
-    {
-      "wordClass": "",
-      "definitions": ["carry"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "were": [
-    {
-      "wordClass": "",
-      "definitions": ["took"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "sayensị": [
-    {
-      "wordClass": "",
-      "definitions": ["science"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "eri": [
-    {
-      "wordClass": "",
-      "definitions": ["eat"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "enyi": [
-    {
-      "wordClass": "",
-      "definitions": ["friend"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "malitere": [
-    {
-      "wordClass": "",
-      "definitions": ["began"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "echiche": [
-    {
-      "wordClass": "",
-      "definitions": ["idea"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "kwụsị": [
-    {
-      "wordClass": "",
-      "definitions": ["stop"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ozugbo": [
-    {
-      "wordClass": "",
-      "definitions": ["instant"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "hear": [
-    {
-      "wordClass": "",
-      "definitions": ["hear"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ịnyịnya": [
-    {
-      "wordClass": "",
-      "definitions": ["horse"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ịkpụ": [
-    {
-      "wordClass": "",
-      "definitions": ["cut"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "hụ": [
-    {
-      "wordClass": "",
-      "definitions": ["sure"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-ekiri": [
-    {
-      "wordClass": "",
-      "definitions": ["watch"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "agba": [
-    {
-      "wordClass": "",
-      "definitions": ["segment"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ihu": [
-    {
-      "wordClass": "",
-      "definitions": ["edge"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "oghe": [
-    {
-      "wordClass": "",
-      "definitions": ["open"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "iyi": [
-    {
-      "wordClass": "",
-      "definitions": ["appear"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọnụ": [
-    {
-      "wordClass": "",
-      "definitions": ["mouth"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọcha": [
-    {
-      "wordClass": "",
-      "definitions": ["white"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ụmụ": [
-    {
-      "wordClass": "",
-      "definitions": ["children"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-amalite": [
-    {
-      "wordClass": "",
-      "definitions": ["begin"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-eje ije": [
-    {
-      "wordClass": "",
-      "definitions": ["walk"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "atụ": [
-    {
-      "wordClass": "",
-      "definitions": ["example"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mfe": [
-    {
-      "wordClass": "",
-      "definitions": ["simple"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mgbe nile": [
-    {
-      "wordClass": "",
-      "definitions": ["always"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "music": [
-    {
-      "wordClass": "",
-      "definitions": ["music"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ozi": [
-    {
-      "wordClass": "",
-      "definitions": ["serve"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ruo mgbe": [
-    {
-      "wordClass": "",
-      "definitions": ["until"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mile": [
-    {
-      "wordClass": "",
-      "definitions": ["mile"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ụgbọ ala": [
-    {
-      "wordClass": "",
-      "definitions": ["car"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ụkwụ": [
-    {
-      "wordClass": "",
-      "definitions": ["leg"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nlekọta": [
-    {
-      "wordClass": "",
-      "definitions": ["care"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nke abụọ": [
-    {
-      "wordClass": "",
-      "definitions": ["second"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ezuru": [
-    {
-      "wordClass": "",
-      "definitions": ["enough"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "larịị": [
-    {
-      "wordClass": "",
-      "definitions": ["level"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nwa agbọghọ": [
-    {
-      "wordClass": "",
-      "definitions": ["girl"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-adị": [
-    {
-      "wordClass": "",
-      "definitions": ["usual"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "njikere": [
-    {
-      "wordClass": "",
-      "definitions": ["ready"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "acha ọbara ọbara": [
-    {
-      "wordClass": "",
-      "definitions": ["red"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ndepụta": [
-    {
-      "wordClass": "",
-      "definitions": ["feed"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ezie": [
-    {
-      "wordClass": "",
-      "definitions": ["though"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-eche": [
-    {
-      "wordClass": "",
-      "definitions": ["wonder"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nnụnụ": [
-    {
-      "wordClass": "",
-      "definitions": ["bird"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ozu": [
-    {
-      "wordClass": "",
-      "definitions": ["body"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nkịta": [
-    {
-      "wordClass": "",
-      "definitions": ["dog"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ezinụlọ": [
-    {
-      "wordClass": "",
-      "definitions": ["family"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "kpọmkwem": [
-    {
-      "wordClass": "",
-      "definitions": ["exact"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "abụrụ": [
-    {
-      "wordClass": "",
-      "definitions": ["pose"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ahapụ": [
-    {
-      "wordClass": "",
-      "definitions": ["leave"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "song": [
-    {
-      "wordClass": "",
-      "definitions": ["song"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ịlele": [
-    {
-      "wordClass": "",
-      "definitions": ["check"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ngwaahịa": [
-    {
-      "wordClass": "",
-      "definitions": ["product"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ojii": [
-    {
-      "wordClass": "",
-      "definitions": ["black"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "onuogugu": [
-    {
-      "wordClass": "",
-      "definitions": ["numeral"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ifufe": [
-    {
-      "wordClass": "",
-      "definitions": ["wind"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ajụjụ": [
-    {
-      "wordClass": "",
-      "definitions": ["question"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "zuru oke": [
-    {
-      "wordClass": "",
-      "definitions": ["complete"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ụgbọ mmiri": [
-    {
-      "wordClass": "",
-      "definitions": ["boat"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mpaghara": [
-    {
-      "wordClass": "",
-      "definitions": ["region"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọkara": [
-    {
-      "wordClass": "",
-      "definitions": ["half"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nkume": [
-    {
-      "wordClass": "",
-      "definitions": ["stone"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọkụ": [
-    {
-      "wordClass": "",
-      "definitions": ["burn"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ndịda": [
-    {
-      "wordClass": "",
-      "definitions": ["south"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nsogbu": [
-    {
-      "wordClass": "",
-      "definitions": ["trouble"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ibe": [
-    {
-      "wordClass": "",
-      "definitions": ["piece"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "gwara": [
-    {
-      "wordClass": "",
-      "definitions": ["told"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "maara": [
-    {
-      "wordClass": "",
-      "definitions": ["knew"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "gafere": [
-    {
-      "wordClass": "",
-      "definitions": ["pass"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "top": [
-    {
-      "wordClass": "",
-      "definitions": ["top"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "dum": [
-    {
-      "wordClass": "",
-      "definitions": ["whole"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "eze": [
-    {
-      "wordClass": "",
-      "definitions": ["king"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’okporo ámá": [
-    {
-      "wordClass": "",
-      "definitions": ["street"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "buru ibu dị sentimita": [
-    {
-      "wordClass": "",
-      "definitions": ["inch"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mụbaa": [
-    {
-      "wordClass": "",
-      "definitions": ["multiply"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "N’ezie": [
-    {
-      "wordClass": "",
-      "definitions": ["course"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "wheel": [
-    {
-      "wordClass": "",
-      "definitions": ["wheel"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "zuru": [
-    {
-      "wordClass": "",
-      "definitions": ["full"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "acha anụnụ anụnụ": [
-    {
-      "wordClass": "",
-      "definitions": ["blue"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ikpebi": [
-    {
-      "wordClass": "",
-      "definitions": ["decide"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "miri": [
-    {
-      "wordClass": "",
-      "definitions": ["deep"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọnwa": [
-    {
-      "wordClass": "",
-      "definitions": ["month"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "agwaetiti": [
-    {
-      "wordClass": "",
-      "definitions": ["island"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "usoro": [
-    {
-      "wordClass": "",
-      "definitions": ["process"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "arụsi ọrụ ike": [
-    {
-      "wordClass": "",
-      "definitions": ["busy"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ule": [
-    {
-      "wordClass": "",
-      "definitions": ["test"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ndekọ": [
-    {
-      "wordClass": "",
-      "definitions": ["record"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọsọ": [
-    {
-      "wordClass": "",
-      "definitions": ["speed"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọlaedo": [
-    {
-      "wordClass": "",
-      "definitions": ["gold"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "kwere omume": [
-    {
-      "wordClass": "",
-      "definitions": ["possible"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ụgbọelu": [
-    {
-      "wordClass": "",
-      "definitions": ["plane"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "itie": [
-    {
-      "wordClass": "",
-      "definitions": ["stead"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "akọrọ": [
-    {
-      "wordClass": "",
-      "definitions": ["dry"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ochi": [
-    {
-      "wordClass": "",
-      "definitions": ["laugh"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "puku": [
-    {
-      "wordClass": "",
-      "definitions": ["thousand"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "gara aga": [
-    {
-      "wordClass": "",
-      "definitions": ["ago"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "efehe": [
-    {
-      "wordClass": "",
-      "definitions": ["ran"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "egwuregwu": [
-    {
-      "wordClass": "",
-      "definitions": ["match"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọdịdị": [
-    {
-      "wordClass": "",
-      "definitions": ["shape"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "equate": [
-    {
-      "wordClass": "",
-      "definitions": ["equate"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "igafe ihe": [
-    {
-      "wordClass": "",
-      "definitions": ["miss"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "okpomọkụ": [
-    {
-      "wordClass": "",
-      "definitions": ["heat"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "snow": [
-    {
-      "wordClass": "",
-      "definitions": ["snow"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "taya": [
-    {
-      "wordClass": "",
-      "definitions": ["tire"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ee": [
-    {
-      "wordClass": "",
-      "definitions": ["yes"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ju": [
-    {
-      "wordClass": "",
-      "definitions": ["fill"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’ebe ọwụwa anyanwụ": [
-    {
-      "wordClass": "",
-      "definitions": ["east"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "asụsụ": [
-    {
-      "wordClass": "",
-      "definitions": ["language"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "unit": [
-    {
-      "wordClass": "",
-      "definitions": ["unit"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ofufe": [
-    {
-      "wordClass": "",
-      "definitions": ["fly"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mbu": [
-    {
-      "wordClass": "",
-      "definitions": ["lead"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mkpu": [
-    {
-      "wordClass": "",
-      "definitions": ["cry"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "gbara ọchịchịrị": [
-    {
-      "wordClass": "",
-      "definitions": ["dark"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "igwe": [
-    {
-      "wordClass": "",
-      "definitions": ["machine"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "atụmatụ": [
-    {
-      "wordClass": "",
-      "definitions": ["plan"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "kpakpando": [
-    {
-      "wordClass": "",
-      "definitions": ["star"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "igbe": [
-    {
-      "wordClass": "",
-      "definitions": ["box"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ubi": [
-    {
-      "wordClass": "",
-      "definitions": ["garden"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ziri ezi": [
-    {
-      "wordClass": "",
-      "definitions": ["correct"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "paụnd": [
-    {
-      "wordClass": "",
-      "definitions": ["pound"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ịma mma": [
-    {
-      "wordClass": "",
-      "definitions": ["beauty"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mbanye": [
-    {
-      "wordClass": "",
-      "definitions": ["drive"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "guzoro": [
-    {
-      "wordClass": "",
-      "definitions": ["stood"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-akụziri": [
-    {
-      "wordClass": "",
-      "definitions": ["teach"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "izu": [
-    {
-      "wordClass": "",
-      "definitions": ["week"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nyere": [
-    {
-      "wordClass": "",
-      "definitions": ["gave"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "akwụkwọ ndụ akwụkwọ ndụ": [
-    {
-      "wordClass": "",
-      "definitions": ["green"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na na na oh": [
-    {
-      "wordClass": "",
-      "definitions": ["oh"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ngwa ngwa": [
-    {
-      "wordClass": "",
-      "definitions": ["quick"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "imepe": [
-    {
-      "wordClass": "",
-      "definitions": ["develop"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "oké osimiri": [
-    {
-      "wordClass": "",
-      "definitions": ["ocean"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "free": [
-    {
-      "wordClass": "",
-      "definitions": ["free"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nkeji": [
-    {
-      "wordClass": "",
-      "definitions": ["minute"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "pụrụ iche": [
-    {
-      "wordClass": "",
-      "definitions": ["special"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "uche": [
-    {
-      "wordClass": "",
-      "definitions": ["sense"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’azụ": [
-    {
-      "wordClass": "",
-      "definitions": ["behind"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "doro anya": [
-    {
-      "wordClass": "",
-      "definitions": ["clear"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọdụ": [
-    {
-      "wordClass": "",
-      "definitions": ["sit"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mepụta": [
-    {
-      "wordClass": "",
-      "definitions": ["produce"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "N’eziokwu": [
-    {
-      "wordClass": "",
-      "definitions": ["fact"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ohere": [
-    {
-      "wordClass": "",
-      "definitions": ["chance"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nụrụ": [
-    {
-      "wordClass": "",
-      "definitions": ["heard"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "awa": [
-    {
-      "wordClass": "",
-      "definitions": ["hour"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ezi": [
-    {
-      "wordClass": "",
-      "definitions": ["true"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’oge": [
-    {
-      "wordClass": "",
-      "definitions": ["season"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "narị": [
-    {
-      "wordClass": "",
-      "definitions": ["hundred"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-echeta": [
-    {
-      "wordClass": "",
-      "definitions": ["remember"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nzọụkwụ": [
-    {
-      "wordClass": "",
-      "definitions": ["step"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’isi": [
-    {
-      "wordClass": "",
-      "definitions": ["finish"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "jide": [
-    {
-      "wordClass": "",
-      "definitions": ["hold"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’ebe ọdịda anyanwụ": [
-    {
-      "wordClass": "",
-      "definitions": ["west"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’ala": [
-    {
-      "wordClass": "",
-      "definitions": ["ground"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mmasị": [
-    {
-      "wordClass": "",
-      "definitions": ["interest"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "iru": [
-    {
-      "wordClass": "",
-      "definitions": ["reach"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ngwa-ngwa": [
-    {
-      "wordClass": "",
-      "definitions": ["fast"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ngwaa": [
-    {
-      "wordClass": "",
-      "definitions": ["verb"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-abụ abụ": [
-    {
-      "wordClass": "",
-      "definitions": ["sing"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ntị": [
-    {
-      "wordClass": "",
-      "definitions": ["ear"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "isii": [
-    {
-      "wordClass": "",
-      "definitions": ["six"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "okpokoro": [
-    {
-      "wordClass": "",
-      "definitions": ["table"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "njem": [
-    {
-      "wordClass": "",
-      "definitions": ["trip"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "Mpekarị": [
-    {
-      "wordClass": "",
-      "definitions": ["less"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ụtụtụ": [
-    {
-      "wordClass": "",
-      "definitions": ["morning"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "iri": [
-    {
-      "wordClass": "",
-      "definitions": ["ten"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ụdaume": [
-    {
-      "wordClass": "",
-      "definitions": ["vowel"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’ebe": [
-    {
-      "wordClass": "",
-      "definitions": ["toward"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "agha": [
-    {
-      "wordClass": "",
-      "definitions": ["soldier"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "dina": [
-    {
-      "wordClass": "",
-      "definitions": ["lay"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "megide": [
-    {
-      "wordClass": "",
-      "definitions": ["against"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ụkpụrụ": [
-    {
-      "wordClass": "",
-      "definitions": ["pattern"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ngwa": [
-    {
-      "wordClass": "",
-      "definitions": ["organ"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’anya": [
-    {
-      "wordClass": "",
-      "definitions": ["sight"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ego": [
-    {
-      "wordClass": "",
-      "definitions": ["slip"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "okporo ụzọ": [
-    {
-      "wordClass": "",
-      "definitions": ["road"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "map": [
-    {
-      "wordClass": "",
-      "definitions": ["map"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mmiri ozuzo": [
-    {
-      "wordClass": "",
-      "definitions": ["rain"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọchịchị": [
-    {
-      "wordClass": "",
-      "definitions": ["rule"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "Dọọ": [
-    {
-      "wordClass": "",
-      "definitions": ["pull"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "oyi": [
-    {
-      "wordClass": "",
-      "definitions": ["winter"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "olu": [
-    {
-      "wordClass": "",
-      "definitions": ["neck"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ichu nta": [
-    {
-      "wordClass": "",
-      "definitions": ["hunt"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "puru omume": [
-    {
-      "wordClass": "",
-      "definitions": ["probable"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "bed": [
-    {
-      "wordClass": "",
-      "definitions": ["bed"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nwanne": [
-    {
-      "wordClass": "",
-      "definitions": ["brother"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-agba ịnyịnya": [
-    {
-      "wordClass": "",
-      "definitions": ["ride"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "cell": [
-    {
-      "wordClass": "",
-      "definitions": ["cell"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "kwere": [
-    {
-      "wordClass": "",
-      "definitions": ["believe"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ikekwe": [
-    {
-      "wordClass": "",
-      "definitions": ["perhaps"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "bulie": [
-    {
-      "wordClass": "",
-      "definitions": ["raise"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mberede": [
-    {
-      "wordClass": "",
-      "definitions": ["sudden"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ịgụ": [
-    {
-      "wordClass": "",
-      "definitions": ["count"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "square": [
-    {
-      "wordClass": "",
-      "definitions": ["square"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-anọchite anya": [
-    {
-      "wordClass": "",
-      "definitions": ["represent"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nkà": [
-    {
-      "wordClass": "",
-      "definitions": ["skill"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "isiokwu": [
-    {
-      "wordClass": "",
-      "definitions": ["subject"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "size": [
-    {
-      "wordClass": "",
-      "definitions": ["size"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "iche iche": [
-    {
-      "wordClass": "",
-      "definitions": ["separate"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "dozie": [
-    {
-      "wordClass": "",
-      "definitions": ["settle"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-ekwu okwu": [
-    {
-      "wordClass": "",
-      "definitions": ["speak"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "arọ": [
-    {
-      "wordClass": "",
-      "definitions": ["heavy"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’ozuzu": [
-    {
-      "wordClass": "",
-      "definitions": ["general"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ice": [
-    {
-      "wordClass": "",
-      "definitions": ["ice"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-agụnye": [
-    {
-      "wordClass": "",
-      "definitions": ["include"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nkeji okwu": [
-    {
-      "wordClass": "",
-      "definitions": ["syllable"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "bọl": [
-    {
-      "wordClass": "",
-      "definitions": ["ball"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ife": [
-    {
-      "wordClass": "",
-      "definitions": ["wave"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "dobe": [
-    {
-      "wordClass": "",
-      "definitions": ["drop"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "obi": [
-    {
-      "wordClass": "",
-      "definitions": ["heart"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "agba egwú": [
-    {
-      "wordClass": "",
-      "definitions": ["dance"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "engine": [
-    {
-      "wordClass": "",
-      "definitions": ["engine"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọnọdụ": [
-    {
-      "wordClass": "",
-      "definitions": ["condition"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ogwe aka": [
-    {
-      "wordClass": "",
-      "definitions": ["arm"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’obosara": [
-    {
-      "wordClass": "",
-      "definitions": ["wide"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-akwọpụ": [
-    {
-      "wordClass": "",
-      "definitions": ["sail"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọhịa": [
-    {
-      "wordClass": "",
-      "definitions": ["forest"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "agbụrụ": [
-    {
-      "wordClass": "",
-      "definitions": ["race"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "windo": [
-    {
-      "wordClass": "",
-      "definitions": ["window"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ụlọ ahịa": [
-    {
-      "wordClass": "",
-      "definitions": ["shop"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’oge okpomọkụ": [
-    {
-      "wordClass": "",
-      "definitions": ["summer"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ụgbọ": [
-    {
-      "wordClass": "",
-      "definitions": ["train"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ụra": [
-    {
-      "wordClass": "",
-      "definitions": ["sleep"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "gosi": [
-    {
-      "wordClass": "",
-      "definitions": ["prove"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nanị": [
-    {
-      "wordClass": "",
-      "definitions": ["lone"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mmega": [
-    {
-      "wordClass": "",
-      "definitions": ["exercise"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mgbidi": [
-    {
-      "wordClass": "",
-      "definitions": ["wall"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "gbutere": [
-    {
-      "wordClass": "",
-      "definitions": ["catch"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’ugwu": [
-    {
-      "wordClass": "",
-      "definitions": ["mount"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "elu-igwe": [
-    {
-      "wordClass": "",
-      "definitions": ["sky"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọṅụ": [
-    {
-      "wordClass": "",
-      "definitions": ["joy"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nọdụ": [
-    {
-      "wordClass": "",
-      "definitions": ["sat"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "dere": [
-    {
-      "wordClass": "",
-      "definitions": ["wrote"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "anụ ọhịa": [
-    {
-      "wordClass": "",
-      "definitions": ["wild"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ngwá": [
-    {
-      "wordClass": "",
-      "definitions": ["instrument"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "iko": [
-    {
-      "wordClass": "",
-      "definitions": ["glass"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ahịhịa": [
-    {
-      "wordClass": "",
-      "definitions": ["grass"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ehi": [
-    {
-      "wordClass": "",
-      "definitions": ["cow"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ịrịba ama": [
-    {
-      "wordClass": "",
-      "definitions": ["sign"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nleta": [
-    {
-      "wordClass": "",
-      "definitions": ["visit"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’oge gara aga": [
-    {
-      "wordClass": "",
-      "definitions": ["past"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nro": [
-    {
-      "wordClass": "",
-      "definitions": ["soft"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọchị": [
-    {
-      "wordClass": "",
-      "definitions": ["smile"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "enwu enwu,": [
-    {
-      "wordClass": "",
-      "definitions": ["bright"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "gas": [
-    {
-      "wordClass": "",
-      "definitions": ["gas"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ihu igwe": [
-    {
-      "wordClass": "",
-      "definitions": ["weather"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nde": [
-    {
-      "wordClass": "",
-      "definitions": ["million"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "obi ụtọ": [
-    {
-      "wordClass": "",
-      "definitions": ["happy"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nwere olileanya": [
-    {
-      "wordClass": "",
-      "definitions": ["hope"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ifuru": [
-    {
-      "wordClass": "",
-      "definitions": ["flower"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "uwe": [
-    {
-      "wordClass": "",
-      "definitions": ["coat"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "gawara": [
-    {
-      "wordClass": "",
-      "definitions": ["gone"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "Abụ olu ụtọ": [
-    {
-      "wordClass": "",
-      "definitions": ["melody"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "enweta": [
-    {
-      "wordClass": "",
-      "definitions": ["supply"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’ahịrị": [
-    {
-      "wordClass": "",
-      "definitions": ["row"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "anwụ": [
-    {
-      "wordClass": "",
-      "definitions": ["die"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "dịkarịa ala,": [
-    {
-      "wordClass": "",
-      "definitions": ["least"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "tie mkpu": [
-    {
-      "wordClass": "",
-      "definitions": ["shout"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ma e wezụga": [
-    {
-      "wordClass": "",
-      "definitions": ["except"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mkpụrụ": [
-    {
-      "wordClass": "",
-      "definitions": ["fruit"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "sonyere": [
-    {
-      "wordClass": "",
-      "definitions": ["join"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-atụ aro": [
-    {
-      "wordClass": "",
-      "definitions": ["suggest"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "dị ọcha": [
-    {
-      "wordClass": "",
-      "definitions": ["clean"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nkwụsịtụ": [
-    {
-      "wordClass": "",
-      "definitions": ["break"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nwanyị": [
-    {
-      "wordClass": "",
-      "definitions": ["woman"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-aza èzí": [
-    {
-      "wordClass": "",
-      "definitions": ["yard"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "bilie": [
-    {
-      "wordClass": "",
-      "definitions": ["rose"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọjọọ": [
-    {
-      "wordClass": "",
-      "definitions": ["bad"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "igbu": [
-    {
-      "wordClass": "",
-      "definitions": ["kill"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mmanụ": [
-    {
-      "wordClass": "",
-      "definitions": ["oil"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọbara": [
-    {
-      "wordClass": "",
-      "definitions": ["blood"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "metụ": [
-    {
-      "wordClass": "",
-      "definitions": ["touch"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "pasent": [
-    {
-      "wordClass": "",
-      "definitions": ["cent"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mix": [
-    {
-      "wordClass": "",
-      "definitions": ["mix"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "izipu": [
-    {
-      "wordClass": "",
-      "definitions": ["wire"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-eri": [
-    {
-      "wordClass": "",
-      "definitions": ["cost"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "furu efu": [
-    {
-      "wordClass": "",
-      "definitions": ["lost"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na agba aja aja": [
-    {
-      "wordClass": "",
-      "definitions": ["brown"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "eyi": [
-    {
-      "wordClass": "",
-      "definitions": ["wear"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "hara": [
-    {
-      "wordClass": "",
-      "definitions": ["equal"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "zitere": [
-    {
-      "wordClass": "",
-      "definitions": ["sent"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "họrọ": [
-    {
-      "wordClass": "",
-      "definitions": ["select"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "dara": [
-    {
-      "wordClass": "",
-      "definitions": ["fell"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "kwekọrọ": [
-    {
-      "wordClass": "",
-      "definitions": ["fit"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "asọpụta": [
-    {
-      "wordClass": "",
-      "definitions": ["flow"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "akụ": [
-    {
-      "wordClass": "",
-      "definitions": ["bank"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-anakọta": [
-    {
-      "wordClass": "",
-      "definitions": ["collect"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "azọpụta": [
-    {
-      "wordClass": "",
-      "definitions": ["save"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ntụpọ": [
-    {
-      "wordClass": "",
-      "definitions": ["decimal"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mebiri": [
-    {
-      "wordClass": "",
-      "definitions": ["broke"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọdọ mmiri": [
-    {
-      "wordClass": "",
-      "definitions": ["lake"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’ọtụtụ na": [
-    {
-      "wordClass": "",
-      "definitions": ["scale"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "oké": [
-    {
-      "wordClass": "",
-      "definitions": ["thick"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-edebe": [
-    {
-      "wordClass": "",
-      "definitions": ["observe"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mgbochiume": [
-    {
-      "wordClass": "",
-      "definitions": ["consonant"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọkọwa okwu": [
-    {
-      "wordClass": "",
-      "definitions": ["dictionary"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mmiri ara": [
-    {
-      "wordClass": "",
-      "definitions": ["milk"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ịkwụ ụgwọ": [
-    {
-      "wordClass": "",
-      "definitions": ["pay"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ngalaba": [
-    {
-      "wordClass": "",
-      "definitions": ["section"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ígwé ojii": [
-    {
-      "wordClass": "",
-      "definitions": ["cloud"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "jụụ": [
-    {
-      "wordClass": "",
-      "definitions": ["cool"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọrịrị": [
-    {
-      "wordClass": "",
-      "definitions": ["climb"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "imewe": [
-    {
-      "wordClass": "",
-      "definitions": ["design"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ogbenye": [
-    {
-      "wordClass": "",
-      "definitions": ["poor"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nnwale": [
-    {
-      "wordClass": "",
-      "definitions": ["experiment"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "igodo": [
-    {
-      "wordClass": "",
-      "definitions": ["key"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ígwè": [
-    {
-      "wordClass": "",
-      "definitions": ["metal"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mkpisi": [
-    {
-      "wordClass": "",
-      "definitions": ["stick"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "iri abụọ na": [
-    {
-      "wordClass": "",
-      "definitions": ["twenty"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "akpụkpọ": [
-    {
-      "wordClass": "",
-      "definitions": ["skin"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ahịrị": [
-    {
-      "wordClass": "",
-      "definitions": ["crease"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "oghere": [
-    {
-      "wordClass": "",
-      "definitions": ["hole"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-awụlikwa elu": [
-    {
-      "wordClass": "",
-      "definitions": ["jump"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "asatọ": [
-    {
-      "wordClass": "",
-      "definitions": ["eight"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "zukoro": [
-    {
-      "wordClass": "",
-      "definitions": ["meet"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mgbọrọgwụ": [
-    {
-      "wordClass": "",
-      "definitions": ["root"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ịzụta": [
-    {
-      "wordClass": "",
-      "definitions": ["buy"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "idozi": [
-    {
-      "wordClass": "",
-      "definitions": ["solve"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "Kwaa": [
-    {
-      "wordClass": "",
-      "definitions": ["push"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "asaa": [
-    {
-      "wordClass": "",
-      "definitions": ["seven"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "paragraf": [
-    {
-      "wordClass": "",
-      "definitions": ["paragraph"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mkpọrọgwụ": [
-    {
-      "wordClass": "",
-      "definitions": ["held"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ntutu isi": [
-    {
-      "wordClass": "",
-      "definitions": ["hair"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "kọwaa": [
-    {
-      "wordClass": "",
-      "definitions": ["describe"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "isi nri": [
-    {
-      "wordClass": "",
-      "definitions": ["cook"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "N’ihi": [
-    {
-      "wordClass": "",
-      "definitions": ["result"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nchebe": [
-    {
-      "wordClass": "",
-      "definitions": ["safe"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "pusi": [
-    {
-      "wordClass": "",
-      "definitions": ["cat"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na narị afọ": [
-    {
-      "wordClass": "",
-      "definitions": ["century"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "tụlee": [
-    {
-      "wordClass": "",
-      "definitions": ["discuss"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "iwu": [
-    {
-      "wordClass": "",
-      "definitions": ["law"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "bit": [
-    {
-      "wordClass": "",
-      "definitions": ["bit"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’ụsọ oké osimiri": [
-    {
-      "wordClass": "",
-      "definitions": ["coast"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nkịtị": [
-    {
-      "wordClass": "",
-      "definitions": ["silent"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "aja": [
-    {
-      "wordClass": "",
-      "definitions": ["sand"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mpịakọta": [
-    {
-      "wordClass": "",
-      "definitions": ["roll"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọnọdụ okpomọkụ": [
-    {
-      "wordClass": "",
-      "definitions": ["temperature"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ụlọ ọrụ": [
-    {
-      "wordClass": "",
-      "definitions": ["company"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "uru": [
-    {
-      "wordClass": "",
-      "definitions": ["value"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ụgha": [
-    {
-      "wordClass": "",
-      "definitions": ["lie"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "uda": [
-    {
-      "wordClass": "",
-      "definitions": ["beat"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ejikere": [
-    {
-      "wordClass": "",
-      "definitions": ["excite"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "eke": [
-    {
-      "wordClass": "",
-      "definitions": ["natural"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ele": [
-    {
-      "wordClass": "",
-      "definitions": ["view"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "isi obodo": [
-    {
-      "wordClass": "",
-      "definitions": ["capital"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "agaghị": [
-    {
-      "wordClass": "",
-      "definitions": ["won’t"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "oche": [
-    {
-      "wordClass": "",
-      "definitions": ["seat"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "Ihe egwu": [
-    {
-      "wordClass": "",
-      "definitions": ["danger"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọgaranya": [
-    {
-      "wordClass": "",
-      "definitions": ["rich"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "dọkịta": [
-    {
-      "wordClass": "",
-      "definitions": ["doctor"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "biko": [
-    {
-      "wordClass": "",
-      "definitions": ["please"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "chebe": [
-    {
-      "wordClass": "",
-      "definitions": ["protect"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ehihie": [
-    {
-      "wordClass": "",
-      "definitions": ["noon"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọkụkụ": [
-    {
-      "wordClass": "",
-      "definitions": ["crop"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’oge a": [
-    {
-      "wordClass": "",
-      "definitions": ["modern"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mmewere": [
-    {
-      "wordClass": "",
-      "definitions": ["element"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "kụrụ": [
-    {
-      "wordClass": "",
-      "definitions": ["hit"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-amụrụ": [
-    {
-      "wordClass": "",
-      "definitions": ["student"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "chọta": [
-    {
-      "wordClass": "",
-      "definitions": ["locate"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mgbanaka": [
-    {
-      "wordClass": "",
-      "definitions": ["ring"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "agwa": [
-    {
-      "wordClass": "",
-      "definitions": ["nature"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ahụhụ": [
-    {
-      "wordClass": "",
-      "definitions": ["insect"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "jidere": [
-    {
-      "wordClass": "",
-      "definitions": ["caught"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "egosi": [
-    {
-      "wordClass": "",
-      "definitions": ["indicate"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "redio": [
-    {
-      "wordClass": "",
-      "definitions": ["radio"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "atọm": [
-    {
-      "wordClass": "",
-      "definitions": ["atom"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mmadụ": [
-    {
-      "wordClass": "",
-      "definitions": ["human"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "akụkọ ihe mere eme": [
-    {
-      "wordClass": "",
-      "definitions": ["history"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mmetụta": [
-    {
-      "wordClass": "",
-      "definitions": ["effect"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "electric": [
-    {
-      "wordClass": "",
-      "definitions": ["electric"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-atụ anya": [
-    {
-      "wordClass": "",
-      "definitions": ["expect"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọkpụkpụ": [
-    {
-      "wordClass": "",
-      "definitions": ["bone"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "tren": [
-    {
-      "wordClass": "",
-      "definitions": ["rail"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ekweta": [
-    {
-      "wordClass": "",
-      "definitions": ["agree"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "N’ihi ya,": [
-    {
-      "wordClass": "",
-      "definitions": ["thus"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nwayọọ": [
-    {
-      "wordClass": "",
-      "definitions": ["gentle"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "onyeisi": [
-    {
-      "wordClass": "",
-      "definitions": ["captain"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "maa amụma": [
-    {
-      "wordClass": "",
-      "definitions": ["guess"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "dị mkpa": [
-    {
-      "wordClass": "",
-      "definitions": ["necessary"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nkọ": [
-    {
-      "wordClass": "",
-      "definitions": ["sharp"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nku": [
-    {
-      "wordClass": "",
-      "definitions": ["wing"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "agbata obi": [
-    {
-      "wordClass": "",
-      "definitions": ["neighbor"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-asacha": [
-    {
-      "wordClass": "",
-      "definitions": ["wash"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ụsụ": [
-    {
-      "wordClass": "",
-      "definitions": ["bat"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "kama": [
-    {
-      "wordClass": "",
-      "definitions": ["rather"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ìgwè mmadụ": [
-    {
-      "wordClass": "",
-      "definitions": ["crowd"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọka": [
-    {
-      "wordClass": "",
-      "definitions": ["corn"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "tụnyere": [
-    {
-      "wordClass": "",
-      "definitions": ["compare"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "abụ": [
-    {
-      "wordClass": "",
-      "definitions": ["poem"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "eriri": [
-    {
-      "wordClass": "",
-      "definitions": ["rope"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mgbịrịgba": [
-    {
-      "wordClass": "",
-      "definitions": ["bell"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-adabere": [
-    {
-      "wordClass": "",
-      "definitions": ["depend"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "anụ": [
-    {
-      "wordClass": "",
-      "definitions": ["meat"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ite": [
-    {
-      "wordClass": "",
-      "definitions": ["rub"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "tube": [
-    {
-      "wordClass": "",
-      "definitions": ["tube"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ama": [
-    {
-      "wordClass": "",
-      "definitions": ["famous"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "dollar": [
-    {
-      "wordClass": "",
-      "definitions": ["dollar"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "egwu": [
-    {
-      "wordClass": "",
-      "definitions": ["afraid"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "tara": [
-    {
-      "wordClass": "",
-      "definitions": ["thin"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "triangle": [
-    {
-      "wordClass": "",
-      "definitions": ["triangle"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na mbara ala": [
-    {
-      "wordClass": "",
-      "definitions": ["planet"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọsọ ọsọ": [
-    {
-      "wordClass": "",
-      "definitions": ["hurry"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ógbè": [
-    {
-      "wordClass": "",
-      "definitions": ["colony"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "elekere": [
-    {
-      "wordClass": "",
-      "definitions": ["clock"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "tie": [
-    {
-      "wordClass": "",
-      "definitions": ["tie"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "banye": [
-    {
-      "wordClass": "",
-      "definitions": ["log"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "search": [
-    {
-      "wordClass": "",
-      "definitions": ["search"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "iziga": [
-    {
-      "wordClass": "",
-      "definitions": ["send"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "acha odo odo": [
-    {
-      "wordClass": "",
-      "definitions": ["yellow"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "égbè": [
-    {
-      "wordClass": "",
-      "definitions": ["gun"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ekwe": [
-    {
-      "wordClass": "",
-      "definitions": ["allow"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ebipụta": [
-    {
-      "wordClass": "",
-      "definitions": ["print"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nwụrụ anwụ": [
-    {
-      "wordClass": "",
-      "definitions": ["dead"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "desert": [
-    {
-      "wordClass": "",
-      "definitions": ["desert"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ekike": [
-    {
-      "wordClass": "",
-      "definitions": ["suit"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ebulinwu": [
-    {
-      "wordClass": "",
-      "definitions": ["lift"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-abata": [
-    {
-      "wordClass": "",
-      "definitions": ["arrive"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ukwu": [
-    {
-      "wordClass": "",
-      "definitions": ["master"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nne na nna": [
-    {
-      "wordClass": "",
-      "definitions": ["parent"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’ikperé mmiri": [
-    {
-      "wordClass": "",
-      "definitions": ["shore"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nkewa": [
-    {
-      "wordClass": "",
-      "definitions": ["division"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "umi": [
-    {
-      "wordClass": "",
-      "definitions": ["substance"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "amara": [
-    {
-      "wordClass": "",
-      "definitions": ["favor"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ijikọ": [
-    {
-      "wordClass": "",
-      "definitions": ["connect"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "post": [
-    {
-      "wordClass": "",
-      "definitions": ["post"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-eji": [
-    {
-      "wordClass": "",
-      "definitions": ["spend"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mmagba": [
-    {
-      "wordClass": "",
-      "definitions": ["chord"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "abụba": [
-    {
-      "wordClass": "",
-      "definitions": ["fat"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "obi ụtọ na": [
-    {
-      "wordClass": "",
-      "definitions": ["glad"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "òkè": [
-    {
-      "wordClass": "",
-      "definitions": ["share"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "papa": [
-    {
-      "wordClass": "",
-      "definitions": ["dad"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "kwesịrị ekwesị": [
-    {
-      "wordClass": "",
-      "definitions": ["proper"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mmanya": [
-    {
-      "wordClass": "",
-      "definitions": ["bar"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ohu": [
-    {
-      "wordClass": "",
-      "definitions": ["slave"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọbọgwụ": [
-    {
-      "wordClass": "",
-      "definitions": ["duck"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ahịa": [
-    {
-      "wordClass": "",
-      "definitions": ["market"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "n’ókè": [
-    {
-      "wordClass": "",
-      "definitions": ["degree"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "populate": [
-    {
-      "wordClass": "",
-      "definitions": ["populate"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "chick": [
-    {
-      "wordClass": "",
-      "definitions": ["chick"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ezigbo": [
-    {
-      "wordClass": "",
-      "definitions": ["dear"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "onye iro": [
-    {
-      "wordClass": "",
-      "definitions": ["enemy"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "zaghachi": [
-    {
-      "wordClass": "",
-      "definitions": ["reply"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọṅụṅụ": [
-    {
-      "wordClass": "",
-      "definitions": ["drink"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ime": [
-    {
-      "wordClass": "",
-      "definitions": ["occur"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nkwado": [
-    {
-      "wordClass": "",
-      "definitions": ["support"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "uzuoku": [
-    {
-      "wordClass": "",
-      "definitions": ["steam"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ngagharị": [
-    {
-      "wordClass": "",
-      "definitions": ["motion"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "quotient": [
-    {
-      "wordClass": "",
-      "definitions": ["quotient"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ezé": [
-    {
-      "wordClass": "",
-      "definitions": ["teeth"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "iheesereese": [
-    {
-      "wordClass": "",
-      "definitions": ["shell"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "oxygen": [
-    {
-      "wordClass": "",
-      "definitions": ["oxygen"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "sugar": [
-    {
-      "wordClass": "",
-      "definitions": ["sugar"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọnwụ": [
-    {
-      "wordClass": "",
-      "definitions": ["death"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mara mma": [
-    {
-      "wordClass": "",
-      "definitions": ["pretty"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "inyom": [
-    {
-      "wordClass": "",
-      "definitions": ["women"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ngwọta": [
-    {
-      "wordClass": "",
-      "definitions": ["solution"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ndọta": [
-    {
-      "wordClass": "",
-      "definitions": ["magnet"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ọlaọcha": [
-    {
-      "wordClass": "",
-      "definitions": ["silver"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-ekele": [
-    {
-      "wordClass": "",
-      "definitions": ["thank"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "alaka ụlọ ọrụ": [
-    {
-      "wordClass": "",
-      "definitions": ["branch"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "suffix": [
-    {
-      "wordClass": "",
-      "definitions": ["suffix"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "karịsịa": [
-    {
-      "wordClass": "",
-      "definitions": ["particular"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "fig": [
-    {
-      "wordClass": "",
-      "definitions": ["fig"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nwanne nwaanyị": [
-    {
-      "wordClass": "",
-      "definitions": ["sister"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nchara": [
-    {
-      "wordClass": "",
-      "definitions": ["steel"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "yiri": [
-    {
-      "wordClass": "",
-      "definitions": ["similar"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-eduzi": [
-    {
-      "wordClass": "",
-      "definitions": ["guide"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ahụmahụ": [
-    {
-      "wordClass": "",
-      "definitions": ["experience"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "apụl": [
-    {
-      "wordClass": "",
-      "definitions": ["apple"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "zụta": [
-    {
-      "wordClass": "",
-      "definitions": ["bought"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "dugara": [
-    {
-      "wordClass": "",
-      "definitions": ["led"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "pitch": [
-    {
-      "wordClass": "",
-      "definitions": ["pitch"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "uka": [
-    {
-      "wordClass": "",
-      "definitions": ["mass"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "kaadị": [
-    {
-      "wordClass": "",
-      "definitions": ["card"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "gbalaga": [
-    {
-      "wordClass": "",
-      "definitions": ["band"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "imeri": [
-    {
-      "wordClass": "",
-      "definitions": ["win"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nrọ": [
-    {
-      "wordClass": "",
-      "definitions": ["dream"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mgbede": [
-    {
-      "wordClass": "",
-      "definitions": ["evening"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ngwá ọrụ": [
-    {
-      "wordClass": "",
-      "definitions": ["tool"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mkpokọta": [
-    {
-      "wordClass": "",
-      "definitions": ["total"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ísì": [
-    {
-      "wordClass": "",
-      "definitions": ["smell"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na ndagwurugwu": [
-    {
-      "wordClass": "",
-      "definitions": ["valley"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "gbochie": [
-    {
-      "wordClass": "",
-      "definitions": ["block"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "chart": [
-    {
-      "wordClass": "",
-      "definitions": ["chart"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "okpu": [
-    {
-      "wordClass": "",
-      "definitions": ["hat"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ere": [
-    {
-      "wordClass": "",
-      "definitions": ["sell"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ịga nke ọma": [
-    {
-      "wordClass": "",
-      "definitions": ["success"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "iwepu wepu": [
-    {
-      "wordClass": "",
-      "definitions": ["subtract"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "igwu": [
-    {
-      "wordClass": "",
-      "definitions": ["swim"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "abụghị": [
-    {
-      "wordClass": "",
-      "definitions": ["opposite"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nwunye": [
-    {
-      "wordClass": "",
-      "definitions": ["wife"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "akpụkpọ ụkwụ": [
-    {
-      "wordClass": "",
-      "definitions": ["shoe"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ubu": [
-    {
-      "wordClass": "",
-      "definitions": ["shoulder"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-agbasa": [
-    {
-      "wordClass": "",
-      "definitions": ["spread"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "ndokwa": [
-    {
-      "wordClass": "",
-      "definitions": ["arrange"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mara ụlọikwuu": [
-    {
-      "wordClass": "",
-      "definitions": ["camp"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "dịrị": [
-    {
-      "wordClass": "",
-      "definitions": ["invent"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na owu": [
-    {
-      "wordClass": "",
-      "definitions": ["cotton"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "keomumu": [
-    {
-      "wordClass": "",
-      "definitions": ["born"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "chọpụta": [
-    {
-      "wordClass": "",
-      "definitions": ["determine"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "quart": [
-    {
-      "wordClass": "",
-      "definitions": ["quart"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "itoolu": [
-    {
-      "wordClass": "",
-      "definitions": ["nine"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "gwongworo": [
-    {
-      "wordClass": "",
-      "definitions": ["truck"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mkpọtụ": [
-    {
-      "wordClass": "",
-      "definitions": ["noise"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "akpọkọta": [
-    {
-      "wordClass": "",
-      "definitions": ["gather"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "gbatia": [
-    {
-      "wordClass": "",
-      "definitions": ["stretch"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "otutu": [
-    {
-      "wordClass": "",
-      "definitions": ["plural"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na-enwu": [
-    {
-      "wordClass": "",
-      "definitions": ["shine"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "onwunwe": [
-    {
-      "wordClass": "",
-      "definitions": ["property"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "na kọlụm": [
-    {
-      "wordClass": "",
-      "definitions": ["column"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "molekul": [
-    {
-      "wordClass": "",
-      "definitions": ["molecule"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "njọ": [
-    {
-      "wordClass": "",
-      "definitions": ["wrong"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "isi awọ": [
-    {
-      "wordClass": "",
-      "definitions": ["gray"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "megharịa": [
-    {
-      "wordClass": "",
-      "definitions": ["repeat"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "sara mbara": [
-    {
-      "wordClass": "",
-      "definitions": ["broad"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "kwadebe": [
-    {
-      "wordClass": "",
-      "definitions": ["prepare"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "nnu": [
-    {
-      "wordClass": "",
-      "definitions": ["salt"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "imi": [
-    {
-      "wordClass": "",
-      "definitions": ["nose"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "iwe": [
-    {
-      "wordClass": "",
-      "definitions": ["anger"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "mgbarakwa": [
-    {
-      "wordClass": "",
-      "definitions": ["claim"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ],
-  "kọntinent": [
-    {
-      "wordClass": "",
-      "definitions": ["continent"],
-      "examples": [],
-      "phrases": [],
-      "variations": []
-    }
-  ]
+    "dị ka": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "like"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "m": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "mine"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ya": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "him"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "in"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "enye": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "offer"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "bụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "is"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’ihi na": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "for"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ụfọdụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "certain"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ma ọ bụrụ na": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "if"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọrụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "operate"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ha": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "them"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ịbụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "be"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "otu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "party"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nwere": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "contain"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "a": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "a"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "si": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "out"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "site": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "by"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-ekpo ọkụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "warm"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "okwu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "term"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ma": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "either"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ihe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "deal"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "you"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ma ọ bụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "nor"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nke": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "which"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "continue"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "anyị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "our"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ike": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "create"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọzọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "else"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ndị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "those"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "eme": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "done"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "oge": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "period"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ekpe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "left"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "otú": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "so"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "kwuru": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "spoke"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọ bụla": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "every"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ịgwa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "tell"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ke": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "does"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "set": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "set"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "atọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "third"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "chọrọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "require"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ikuku": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "air"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọma": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "well"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "igwu egwu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "play"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "obere": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "tiny"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "njedebe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "end"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "tinye": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "add"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’ụlọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "home"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-agụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "read"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "aka": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "finger"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọdụ ụgbọ mmiri": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "port"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nnukwu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "huge"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "asụpe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "spell"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọbụna": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "even"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ala": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "soil"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ebe a": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "here"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ana": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "charge"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "elu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "up"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "dị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "such"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-eso": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "follow"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ya mere": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "why"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ịjụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "ask"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ndị ikom": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "men"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mgbanwe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "change"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "wee": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "got"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ìhè": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "light"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ụdị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "type"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "anya": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "forward"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mkpa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "need"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ụlọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "room"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "foto": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "picture"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-agbalị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "try"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "anụmanụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "animal"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ebe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "station"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nne": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "mother"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ụwa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "earth"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nso": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "close"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ewu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "build"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "onwe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "self"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nna": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "father"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọhụrụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "fresh"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "akụkụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "fraction"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nara": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "take"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nweta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "get"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mere": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "did"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ndụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "life"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mgbe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "ever"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "azụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "fish"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "naanị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "only"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "gburugburu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "circle"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nwoke": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "man"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "afọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "age"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "izi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "show"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mma": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "fair"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nye": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "provide"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’okpuru": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "under"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "aha": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "noun"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nnọọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "quite"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "site na": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "through"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "dị nnọọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "just"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ikpe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "case"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "akwa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "grand"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "chere": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "felt"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-ekwu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "say"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "akara": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "score"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "iche": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "range"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "N’aka": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "turn"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "kpatara": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "cause"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ukwuu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "much"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "pụtara": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "meant"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’ihu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "front"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nkwaghari": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "move"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nri": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "bread"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nwa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "baby"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ochie": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "old"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "oke": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "too"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "she"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "niile": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "all"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’ebe ahụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "there"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "iji": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "order"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "gị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "your"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ụzọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "path"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "banyere": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "about"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọtụtụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "lot"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mgbe ahụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "then"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "dee": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "note"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ga-": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "shall"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ndị a": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "these"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ogologo": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "tall"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "eme ka": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "make"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ịhụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "see"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "abụọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "double"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ụbọchị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "day"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "aga": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "go"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "bịa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "come"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọnụ ọgụgụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "figure"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ada": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "fall"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mba": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "nation"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "kacha": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "most"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ndị mmadụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "people"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’elu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "surface"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mara": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "notice"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mmiri": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "liquid"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "karịa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "than"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "oku": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "call"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mbụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "original"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "onye": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "whose"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’akụkụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "corner"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "kemgbe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "been"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ugbu a": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "current"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ịchọta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "find"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "isi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "basic"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "eguzo": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "stand"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "peeji nke": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "page"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "kwesịrị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "should"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "obodo": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "village"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "hụrụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "found"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "azịza": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "answer"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ụlọ akwụkwọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "school"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-eto": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "grew"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọmụmụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "study"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ka": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "let"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ịmụta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "learn"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "osisi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "board"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mkpuchi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "cover"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "anyanwụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "sun"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "anọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "stay"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’etiti": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "middle"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ikpeazụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "final"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ịgafe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "cross"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ugbo": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "farm"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mmalite": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "start"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "akụkọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "story"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ikwo": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "saw"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "osimiri": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "river"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ise": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "five"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "omume": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "practice"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "emela": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "don’t"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "akuko": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "press"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "abalị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "night"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’ezie": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "real"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ole na ole": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "few"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ugwu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "hill"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "akwụkwọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "sheet"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ebu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "carry"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "were": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "took"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "sayensị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "science"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "eri": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "eat"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "enyi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "friend"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "malitere": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "began"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "echiche": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "idea"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "kwụsị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "stop"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ozugbo": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "instant"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "hear": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "hear"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ịnyịnya": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "horse"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ịkpụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "cut"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "hụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "sure"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-ekiri": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "watch"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "agba": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "segment"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ihu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "edge"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "oghe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "open"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "iyi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "appear"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọnụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "mouth"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọcha": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "white"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ụmụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "children"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-amalite": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "begin"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-eje ije": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "walk"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "atụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "example"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mfe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "simple"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mgbe nile": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "always"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "music": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "music"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ozi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "serve"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ruo mgbe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "until"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mile": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "mile"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ụgbọ ala": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "car"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ụkwụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "leg"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nlekọta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "care"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nke abụọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "second"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ezuru": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "enough"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "larịị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "level"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nwa agbọghọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "girl"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-adị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "usual"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "njikere": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "ready"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "acha ọbara ọbara": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "red"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ndepụta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "feed"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ezie": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "though"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-eche": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "wonder"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nnụnụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "bird"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ozu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "body"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nkịta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "dog"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ezinụlọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "family"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "kpọmkwem": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "exact"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "abụrụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "pose"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ahapụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "leave"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "song": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "song"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ịlele": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "check"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ngwaahịa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "product"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ojii": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "black"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "onuogugu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "numeral"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ifufe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "wind"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ajụjụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "question"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "zuru oke": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "complete"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ụgbọ mmiri": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "boat"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mpaghara": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "region"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọkara": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "half"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nkume": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "stone"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọkụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "burn"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ndịda": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "south"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nsogbu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "trouble"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ibe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "piece"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "gwara": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "told"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "maara": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "knew"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "gafere": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "pass"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "top": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "top"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "dum": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "whole"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "eze": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "king"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’okporo ámá": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "street"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "buru ibu dị sentimita": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "inch"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mụbaa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "multiply"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "N’ezie": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "course"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "wheel": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "wheel"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "zuru": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "full"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "acha anụnụ anụnụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "blue"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ikpebi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "decide"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "miri": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "deep"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọnwa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "month"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "agwaetiti": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "island"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "usoro": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "process"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "arụsi ọrụ ike": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "busy"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ule": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "test"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ndekọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "record"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọsọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "speed"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọlaedo": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "gold"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "kwere omume": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "possible"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ụgbọelu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "plane"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "itie": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "stead"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "akọrọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "dry"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ochi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "laugh"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "puku": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "thousand"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "gara aga": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "ago"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "efehe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "ran"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "egwuregwu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "match"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọdịdị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "shape"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "equate": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "equate"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "igafe ihe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "miss"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "okpomọkụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "heat"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "snow": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "snow"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "taya": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "tire"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ee": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "yes"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ju": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "fill"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’ebe ọwụwa anyanwụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "east"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "asụsụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "language"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "unit": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "unit"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ofufe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "fly"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mbu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "lead"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mkpu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "cry"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "gbara ọchịchịrị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "dark"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "igwe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "machine"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "atụmatụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "plan"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "kpakpando": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "star"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "igbe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "box"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ubi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "garden"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ziri ezi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "correct"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "paụnd": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "pound"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ịma mma": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "beauty"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mbanye": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "drive"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "guzoro": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "stood"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-akụziri": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "teach"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "izu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "week"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nyere": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "gave"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "akwụkwọ ndụ akwụkwọ ndụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "green"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na na na oh": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "oh"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ngwa ngwa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "quick"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "imepe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "develop"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "oké osimiri": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "ocean"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "free": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "free"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nkeji": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "minute"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "pụrụ iche": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "special"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "uche": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "sense"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’azụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "behind"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "doro anya": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "clear"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọdụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "sit"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mepụta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "produce"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "N’eziokwu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "fact"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ohere": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "chance"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nụrụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "heard"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "awa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "hour"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ezi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "true"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’oge": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "season"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "narị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "hundred"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-echeta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "remember"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nzọụkwụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "step"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’isi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "finish"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "jide": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "hold"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’ebe ọdịda anyanwụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "west"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’ala": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "ground"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mmasị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "interest"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "iru": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "reach"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ngwa-ngwa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "fast"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ngwaa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "verb"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-abụ abụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "sing"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ntị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "ear"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "isii": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "six"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "okpokoro": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "table"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "njem": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "trip"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "Mpekarị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "less"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ụtụtụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "morning"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "iri": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "ten"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ụdaume": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "vowel"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’ebe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "toward"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "agha": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "soldier"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "dina": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "lay"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "megide": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "against"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ụkpụrụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "pattern"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ngwa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "organ"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’anya": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "sight"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ego": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "slip"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "okporo ụzọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "road"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "map": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "map"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mmiri ozuzo": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "rain"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọchịchị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "rule"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "Dọọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "pull"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "oyi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "winter"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "olu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "neck"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ichu nta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "hunt"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "puru omume": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "probable"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "bed": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "bed"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nwanne": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "brother"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-agba ịnyịnya": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "ride"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "cell": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "cell"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "kwere": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "believe"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ikekwe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "perhaps"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "bulie": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "raise"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mberede": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "sudden"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ịgụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "count"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "square": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "square"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-anọchite anya": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "represent"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nkà": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "skill"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "isiokwu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "subject"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "size": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "size"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "iche iche": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "separate"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "dozie": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "settle"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-ekwu okwu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "speak"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "arọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "heavy"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’ozuzu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "general"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ice": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "ice"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-agụnye": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "include"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nkeji okwu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "syllable"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "bọl": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "ball"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ife": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "wave"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "dobe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "drop"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "obi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "heart"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "agba egwú": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "dance"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "engine": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "engine"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọnọdụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "condition"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ogwe aka": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "arm"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’obosara": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "wide"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-akwọpụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "sail"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọhịa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "forest"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "agbụrụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "race"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "windo": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "window"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ụlọ ahịa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "shop"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’oge okpomọkụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "summer"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ụgbọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "train"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ụra": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "sleep"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "gosi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "prove"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nanị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "lone"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mmega": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "exercise"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mgbidi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "wall"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "gbutere": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "catch"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’ugwu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "mount"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "elu-igwe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "sky"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọṅụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "joy"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nọdụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "sat"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "dere": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "wrote"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "anụ ọhịa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "wild"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ngwá": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "instrument"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "iko": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "glass"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ahịhịa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "grass"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ehi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "cow"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ịrịba ama": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "sign"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nleta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "visit"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’oge gara aga": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "past"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nro": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "soft"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọchị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "smile"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "enwu enwu,": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "bright"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "gas": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "gas"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ihu igwe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "weather"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nde": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "million"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "obi ụtọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "happy"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nwere olileanya": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "hope"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ifuru": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "flower"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "uwe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "coat"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "gawara": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "gone"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "Abụ olu ụtọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "melody"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "enweta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "supply"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’ahịrị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "row"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "anwụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "die"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "dịkarịa ala,": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "least"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "tie mkpu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "shout"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ma e wezụga": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "except"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mkpụrụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "fruit"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "sonyere": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "join"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-atụ aro": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "suggest"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "dị ọcha": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "clean"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nkwụsịtụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "break"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nwanyị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "woman"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-aza èzí": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "yard"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "bilie": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "rose"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọjọọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "bad"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "igbu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "kill"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mmanụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "oil"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọbara": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "blood"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "metụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "touch"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "pasent": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "cent"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mix": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "mix"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "izipu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "wire"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-eri": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "cost"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "furu efu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "lost"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na agba aja aja": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "brown"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "eyi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "wear"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "hara": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "equal"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "zitere": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "sent"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "họrọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "select"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "dara": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "fell"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "kwekọrọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "fit"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "asọpụta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "flow"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "akụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "bank"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-anakọta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "collect"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "azọpụta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "save"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ntụpọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "decimal"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mebiri": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "broke"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọdọ mmiri": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "lake"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’ọtụtụ na": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "scale"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "oké": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "thick"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-edebe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "observe"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mgbochiume": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "consonant"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọkọwa okwu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "dictionary"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mmiri ara": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "milk"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ịkwụ ụgwọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "pay"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ngalaba": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "section"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ígwé ojii": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "cloud"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "jụụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "cool"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọrịrị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "climb"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "imewe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "design"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ogbenye": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "poor"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nnwale": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "experiment"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "igodo": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "key"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ígwè": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "metal"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mkpisi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "stick"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "iri abụọ na": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "twenty"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "akpụkpọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "skin"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ahịrị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "crease"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "oghere": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "hole"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-awụlikwa elu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "jump"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "asatọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "eight"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "zukoro": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "meet"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mgbọrọgwụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "root"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ịzụta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "buy"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "idozi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "solve"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "Kwaa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "push"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "asaa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "seven"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "paragraf": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "paragraph"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mkpọrọgwụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "held"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ntutu isi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "hair"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "kọwaa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "describe"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "isi nri": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "cook"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "N’ihi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "result"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nchebe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "safe"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "pusi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "cat"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na narị afọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "century"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "tụlee": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "discuss"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "iwu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "law"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "bit": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "bit"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’ụsọ oké osimiri": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "coast"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nkịtị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "silent"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "aja": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "sand"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mpịakọta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "roll"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọnọdụ okpomọkụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "temperature"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ụlọ ọrụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "company"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "uru": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "value"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ụgha": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "lie"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "uda": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "beat"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ejikere": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "excite"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "eke": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "natural"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ele": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "view"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "isi obodo": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "capital"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "agaghị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "won’t"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "oche": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "seat"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "Ihe egwu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "danger"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọgaranya": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "rich"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "dọkịta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "doctor"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "biko": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "please"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "chebe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "protect"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ehihie": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "noon"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọkụkụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "crop"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’oge a": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "modern"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mmewere": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "element"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "kụrụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "hit"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-amụrụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "student"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "chọta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "locate"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mgbanaka": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "ring"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "agwa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "nature"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ahụhụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "insect"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "jidere": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "caught"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "egosi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "indicate"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "redio": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "radio"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "atọm": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "atom"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mmadụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "human"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "akụkọ ihe mere eme": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "history"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mmetụta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "effect"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "electric": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "electric"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-atụ anya": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "expect"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọkpụkpụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "bone"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "tren": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "rail"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ekweta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "agree"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "N’ihi ya,": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "thus"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nwayọọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "gentle"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "onyeisi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "captain"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "maa amụma": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "guess"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "dị mkpa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "necessary"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nkọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "sharp"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nku": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "wing"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "agbata obi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "neighbor"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-asacha": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "wash"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ụsụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "bat"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "kama": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "rather"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ìgwè mmadụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "crowd"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọka": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "corn"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "tụnyere": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "compare"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "abụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "poem"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "eriri": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "rope"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mgbịrịgba": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "bell"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-adabere": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "depend"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "anụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "meat"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ite": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "rub"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "tube": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "tube"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ama": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "famous"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "dollar": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "dollar"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "egwu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "afraid"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "tara": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "thin"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "triangle": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "triangle"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na mbara ala": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "planet"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọsọ ọsọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "hurry"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ógbè": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "colony"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "elekere": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "clock"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "tie": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "tie"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "banye": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "log"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "search": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "search"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "iziga": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "send"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "acha odo odo": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "yellow"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "égbè": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "gun"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ekwe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "allow"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ebipụta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "print"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nwụrụ anwụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "dead"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "desert": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "desert"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ekike": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "suit"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ebulinwu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "lift"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-abata": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "arrive"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ukwu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "master"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nne na nna": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "parent"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’ikperé mmiri": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "shore"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nkewa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "division"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "umi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "substance"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "amara": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "favor"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ijikọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "connect"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "post": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "post"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-eji": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "spend"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mmagba": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "chord"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "abụba": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "fat"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "obi ụtọ na": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "glad"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "òkè": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "share"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "papa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "dad"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "kwesịrị ekwesị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "proper"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mmanya": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "bar"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ohu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "slave"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọbọgwụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "duck"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ahịa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "market"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "n’ókè": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "degree"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "populate": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "populate"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "chick": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "chick"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ezigbo": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "dear"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "onye iro": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "enemy"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "zaghachi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "reply"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọṅụṅụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "drink"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ime": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "occur"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nkwado": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "support"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "uzuoku": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "steam"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ngagharị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "motion"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "quotient": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "quotient"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ezé": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "teeth"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "iheesereese": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "shell"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "oxygen": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "oxygen"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "sugar": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "sugar"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọnwụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "death"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mara mma": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "pretty"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "inyom": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "women"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ngwọta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "solution"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ndọta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "magnet"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ọlaọcha": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "silver"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-ekele": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "thank"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "alaka ụlọ ọrụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "branch"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "suffix": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "suffix"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "karịsịa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "particular"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "fig": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "fig"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nwanne nwaanyị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "sister"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nchara": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "steel"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "yiri": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "similar"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-eduzi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "guide"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ahụmahụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "experience"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "apụl": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "apple"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "zụta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "bought"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "dugara": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "led"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "pitch": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "pitch"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "uka": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "mass"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "kaadị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "card"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "gbalaga": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "band"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "imeri": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "win"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nrọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "dream"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mgbede": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "evening"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ngwá ọrụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "tool"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mkpokọta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "total"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ísì": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "smell"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na ndagwurugwu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "valley"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "gbochie": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "block"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "chart": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "chart"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "okpu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "hat"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ere": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "sell"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ịga nke ọma": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "success"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "iwepu wepu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "subtract"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "igwu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "swim"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "abụghị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "opposite"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nwunye": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "wife"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "akpụkpọ ụkwụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "shoe"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ubu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "shoulder"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-agbasa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "spread"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "ndokwa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "arrange"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mara ụlọikwuu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "camp"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "dịrị": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "invent"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na owu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "cotton"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "keomumu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "born"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "chọpụta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "determine"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "quart": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "quart"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "itoolu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "nine"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "gwongworo": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "truck"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mkpọtụ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "noise"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "akpọkọta": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "gather"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "gbatia": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "stretch"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "otutu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "plural"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na-enwu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "shine"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "onwunwe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "property"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "na kọlụm": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "column"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "molekul": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "molecule"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "njọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "wrong"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "isi awọ": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "gray"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "megharịa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "repeat"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "sara mbara": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "broad"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "kwadebe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "prepare"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "nnu": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "salt"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "imi": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "nose"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "iwe": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "anger"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "mgbarakwa": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "claim"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ],
+    "kọntinent": [
+        {
+            "wordClass": "",
+            "definitions": [
+                "continent"
+            ],
+            "examples": [],
+            "phrases": [],
+            "variations": []
+        }
+    ]
 }

--- a/src/routers/editorRouter.js
+++ b/src/routers/editorRouter.js
@@ -6,7 +6,7 @@ import {
   putWordSuggestion,
 } from '../controllers/wordSuggestions';
 import { putWord, postWord } from '../controllers/words';
-import { putExample, postExample } from '../controllers/examples';
+import { putExample, postExample, getExamples } from '../controllers/examples';
 import {
   getExampleSuggestion,
   getExampleSuggestions,
@@ -25,296 +25,322 @@ const editorRouter = express.Router();
 /* These routes are used to allow users to suggest new words and examples */
 
 /**
- * @swagger
- * /words:
- *   post:
- *     description: Creates a new Word document
- *     tags:
- *      - development
- *     consumes:
- *       - application/json
- *     parameters:
- *       - in: body
- *         name: body
- *         description: The word that will be created in the database
- *         schema:
- *           type: object
- *           properties:
- *             word:
- *               type: string
- *             wordClass:
- *               type: string
- *             definitions:
- *               type: array
- *               items:
- *                 type: string
- *             variations:
- *               type: array
- *               items:
- *                 type: string
- *   responses:
- *        200:
- *         description: OK
- *         content:
- *          application/json:
- *            schema:
- *              type: object
- *              properties:
- *                id:
- *                type: string
- *
- * /words/{wordId}:
- *   put:
- *     description: Updates a Word object from the database
- *     tags:
- *      - production
- *     consumes:
- *       - application/json
- *     parameters:
- *        - in: path
- *          name: wordId
- *          required: true
- *          schema:
- *            type: string
- *          description: the word id
- *        - in: body
- *          name: body
- *          description: The updated word data
- *          schema:
- *             type: object
- *             properties:
- *              id:
- *                type: string
- *              word:
- *                type: string
- *              wordClass:
- *                type: string
- *              definitions:
- *                type: array
- *                items:
- *                  type: string
- *              variations:
- *               type: array
- *               items:
- *                 type: string
- *     responses:
- *      200:
- *         description: OK
- *         content:
- *          application/json:
- *            schema:
- *              type: object
- *
- * /examples:
- *   get:
- *     description: Get examples in dictionary
- *     tags:
- *      - production
- *     parameters:
- *      - name: keyword
- *        description: keyword for querying examples
- *        in: query
- *        required: false
- *        type: string
- *      - name: page
- *        description: page for results
- *        in: query
- *        required: false
- *        type: integer
- *      - name: range
- *        description: page for results using [x,y] syntax
- *        in: query
- *        required: false
- *        type: string
- *     responses:
- *      200:
- *         description: OK
- *
- *   post:
- *     description: Creates a new Example document
- *     tags:
- *      - development
- *     consumes:
- *       - application/json
- *     parameters:
- *       - in: body
- *         name: body
- *         description: The example that will be created in the database
- *         schema:
- *           type: object
- *           properties:
- *             igbo:
- *               type: string
- *             english:
- *               type: string
- *             associatedWords:
- *               type: array
- *               items:
- *                 type: string
- *   responses:
- *      200:
- *       description: OK
- *
- * /examples/{exampleId}:
- *   put:
- *     description: Updates a Example object from the database
- *     tags:
- *      - production
- *     consumes:
- *       - application/json
- *     parameters:
- *        - in: path
- *          name: exampleId
- *          required: true
- *          schema:
- *            type: string
- *          description: the example id
- *        - in: body
- *          name: body
- *          description: The updated example data
- *          schema:
- *            type: object
- *            properties:
- *              id:
- *                type: string
- *              igbo:
- *                type: string
- *              english:
- *                type: string
- *              associatedWords:
- *                type: array
- *                items:
- *                  type: string
- *     responses:
- *      200:
- *         description: OK
- */
+* @swagger
+* /words:
+*   post:
+*     description: Creates a new Word document
+*     tags:
+*      - development
+*     consumes:
+*       - application/json
+*     parameters:
+*       - in: body
+*         name: body
+*         description: The word that will be created in the database
+*         schema:
+*           type: object
+*           properties:
+*             word:
+*               type: string
+*             wordClass:
+*               type: string
+*             definitions:
+*               type: array
+*               items:
+*                 type: string
+*             variations:
+*               type: array
+*               items:
+*                 type: string
+*   responses:
+*        200:
+*         description: OK
+*         content:
+*          application/json:
+*            schema:
+*              type: object
+*              properties:
+*                id:
+*                type: string
+*
+*/
 editorRouter.post('/words', postWord);
+
+/**
+* @swagger
+* /words/{wordId}:
+*   put:
+*     description: Updates a Word object from the database
+*     tags:
+*      - production
+*     consumes:
+*       - application/json
+*     parameters:
+*        - in: path
+*          name: wordId
+*          required: true
+*          schema:
+*            type: string
+*          description: the word id
+*        - in: body
+*          name: body
+*          description: The updated word data
+*          schema:
+*             type: object
+*             properties:
+*              id:
+*                type: string
+*              word:
+*                type: string
+*              wordClass:
+*                type: string
+*              definitions:
+*                type: array
+*                items:
+*                  type: string
+*              variations:
+*               type: array
+*               items:
+*                 type: string
+*     responses:
+*      200:
+*         description: OK
+*         content:
+*          application/json:
+*            schema:
+*              type: object
+*/
 editorRouter.put('/words/:id', putWord);
+
+/**
+* @swagger
+* /examples:
+*   get:
+*     description: Get examples in dictionary
+*     tags:
+*      - production
+*     parameters:
+*      - name: keyword
+*        description: keyword for querying examples
+*        in: query
+*        required: false
+*        type: string
+*      - name: page
+*        description: page for results
+*        in: query
+*        required: false
+*        type: integer
+*      - name: range
+*        description: page for results using [x,y] syntax
+*        in: query
+*        required: false
+*        type: string
+*     responses:
+*      200:
+*         description: OK
+*/
+editorRouter.get('/examples', getExamples);
+
+/**
+* @swagger
+* /examples:
+*   post:
+*     description: Creates a new Example document
+*     tags:
+*      - development
+*     consumes:
+*       - application/json
+*     parameters:
+*       - in: body
+*         name: body
+*         description: The example that will be created in the database
+*         schema:
+*           type: object
+*           properties:
+*             igbo:
+*               type: string
+*             english:
+*               type: string
+*             associatedWords:
+*               type: array
+*               items:
+*                 type: string
+*   responses:
+*      200:
+*       description: OK
+*/
 editorRouter.post('/examples', postExample);
+
+/**
+* @swagger
+* /examples/{exampleId}:
+*   put:
+*     description: Updates a Example object from the database
+*     tags:
+*      - production
+*     consumes:
+*       - application/json
+*     parameters:
+*        - in: path
+*          name: exampleId
+*          required: true
+*          schema:
+*            type: string
+*          description: the example id
+*        - in: body
+*          name: body
+*          description: The updated example data
+*          schema:
+*            type: object
+*            properties:
+*              id:
+*                type: string
+*              igbo:
+*                type: string
+*              english:
+*                type: string
+*              associatedWords:
+*                type: array
+*                items:
+*                  type: string
+*     responses:
+*      200:
+*         description: OK
+*/
 editorRouter.put('/examples/:id', putExample);
 
 /**
- * @swagger
- * /wordSuggestions:
- *   post:
- *     description: Creates a new WordSuggestion document
- *     tags:
- *      - development
- *     consumes:
- *       - application/json
- *     parameters:
- *       - in: body
- *         name: body
- *         description: The word suggestion that will be created in the database
- *         schema:
- *            type: object
- *            properties:
- *              word:
- *               type: string
- *              wordClass:
- *               type: string
- *              definitions:
- *               type: array
- *               items:
- *                 type: string
- *               variations:
- *                type: array
- *                items:
- *                   type: string
- *     responses:
- *      200:
- *         description: OK
- *         content:
- *          application/json:
- *            schema:
- *              type: object
- *              properties:
- *                id:
- *                type: string
- *
- *   get:
- *      description: Returns all WordSuggestion objects in the database
- *      tags:
- *       - development
- *      consumes:
- *        - application/json
- *      responses:
- *        200:
- *         description: OK
- *         content:
- *          application/json:
- *            schema:
- *              type: object
- *
- * /wordSuggestions/{wordSuggestionId}:
- *   get:
- *      description: Returns a single WordSuggestion object from the database
- *      tags:
- *       - development
- *      consumes:
- *        - application/json
- *      parameters:
- *        - in: path
- *          name: wordSuggestionId
- *          required: true
- *          schema:
- *            type: string
- *          description: the wordSuggestion id
- *      responses:
- *        200:
- *         description: OK
- *         content:
- *          application/json:
- *            schema:
- *              type: object
- *
- *   put:
- *      description: Updates an existing WordSuggestion document
- *      tags:
- *       - development
- *      consumes:
- *        - application/json
- *      parameters:
- *       - in: path
- *         name: wordSuggestionId
- *         required: true
- *         schema:
- *           type: string
- *         description: the wordSuggestion id
- *       - in: body
- *         name: body
- *         description: The updated word suggested data
- *         schema:
- *           type: object
- *           properties:
- *             id:
- *               type: string
- *             word:
- *               type: string
- *             wordClass:
- *               type: string
- *             definitions:
- *               type: array
- *               items:
- *                 type: string
- *             variations:
- *               type: array
- *               items:
- *                 type: string
- *      responses:
- *        200:
- *         description: OK
- *         content:
- *          application/json:
- *            schema:
- *              type: object
- *
- */
+* @swagger
+* /wordSuggestions:
+*   post:
+*     description: Creates a new WordSuggestion document
+*     tags:
+*      - development
+*     consumes:
+*       - application/json
+*     parameters:
+*       - in: body
+*         name: body
+*         description: The word suggestion that will be created in the database
+*         schema:
+*            type: object
+*            properties:
+*              word:
+*               type: string
+*              wordClass:
+*               type: string
+*              definitions:
+*               type: array
+*               items:
+*                 type: string
+*               variations:
+*                type: array
+*                items:
+*                   type: string
+*     responses:
+*      200:
+*         description: OK
+*         content:
+*          application/json:
+*            schema:
+*              type: object
+*              properties:
+*                id:
+*                type: string
+*/
 editorRouter.post('/wordSuggestions', postWordSuggestion);
+
+/**
+* @swagger
+* /wordSuggestions:
+*   get:
+*      description: Returns all WordSuggestion objects in the database
+*      tags:
+*       - development
+*      consumes:
+*        - application/json
+*      responses:
+*        200:
+*         description: OK
+*         content:
+*          application/json:
+*            schema:
+*              type: object
+*/
 editorRouter.get('/wordSuggestions', getWordSuggestions);
-editorRouter.put('/wordSuggestions/:id', putWordSuggestion);
+
+/**
+* @swagger
+* /wordSuggestions/{wordSuggestionId}:
+*   get:
+*      description: Returns a single WordSuggestion object from the database
+*      tags:
+*       - development
+*      consumes:
+*        - application/json
+*      parameters:
+*        - in: path
+*          name: wordSuggestionId
+*          required: true
+*          schema:
+*            type: string
+*          description: the wordSuggestion id
+*      responses:
+*        200:
+*         description: OK
+*         content:
+*          application/json:
+*            schema:
+*              type: object
+*/
 editorRouter.get('/wordSuggestions/:id', getWordSuggestion);
+
+/**
+* @swagger
+* /wordSuggestions/{wordSuggestionId}:
+*   put:
+*      description: Updates an existing WordSuggestion document
+*      tags:
+*       - development
+*      consumes:
+*        - application/json
+*      parameters:
+*       - in: path
+*         name: wordSuggestionId
+*         required: true
+*         schema:
+*           type: string
+*         description: the wordSuggestion id
+*       - in: body
+*         name: body
+*         description: The updated word suggested data
+*         schema:
+*           type: object
+*           properties:
+*             id:
+*               type: string
+*             word:
+*               type: string
+*             wordClass:
+*               type: string
+*             definitions:
+*               type: array
+*               items:
+*                 type: string
+*             variations:
+*               type: array
+*               items:
+*                 type: string
+*      responses:
+*        200:
+*         description: OK
+*         content:
+*          application/json:
+*            schema:
+*              type: object
+*
+*/
+editorRouter.put('/wordSuggestions/:id', putWordSuggestion);
 
 /**
  * @swagger
@@ -350,169 +376,192 @@ editorRouter.get('/wordSuggestions/:id', getWordSuggestion);
  *              properties:
  *                id:
  *                type: string
- *
- *   get:
- *      description: Returns all ExampleSuggestion objects in the database
- *      tags:
- *       - development
- *      consumes:
- *        - application/json
- *      responses:
- *        200:
- *         description: OK
- *         content:
- *          application/json:
- *            schema:
- *              type: object
- *
- * /exampleSuggestions/{exampleSuggestionId}:
- *    get:
- *      description: Returns a single ExampleSuggestion object from the database
- *      tags:
- *       - development
- *      consumes:
- *        - application/json
- *      parameters:
- *        - in: path
- *          name: exampleSuggestionId
- *          required: true
- *          schema:
- *            type: string
- *          description: the exampleSuggestion id
- *      responses:
- *        200:
- *         description: OK
- *         content:
- *          application/json:
- *            schema:
- *              type: object
- *
- *    put:
- *      description: Updates and existing ExampleSuggestion document
- *      tags:
- *       - development
- *      consumes:
- *        - application/json
- *      parameters:
- *       - in: path
- *         name: exampleSuggestionId
- *         required: true
- *         schema:
- *           type: string
- *         description: the exampleSuggestion id
- *       - in: body
- *         name: body
- *         description: The updated example suggested data
- *         schema:
- *           type: object
- *           properties:
- *             id:
- *               type: string
- *             igbo:
- *               type: string
- *             english:
- *               type: string
- *             associatedWords:
- *               type: array
- *               items:
- *                 type: string
- *      responses:
- *        200:
- *         description: OK
- *         content:
- *          application/json:
- *            schema:
- *              type: object
  */
 editorRouter.post('/exampleSuggestions', postExampleSuggestion);
+
+/**
+* @swagger
+* /exampleSuggestions:
+*    get:
+*      description: Returns all ExampleSuggestion objects in the database
+*      tags:
+*       - development
+*      consumes:
+*        - application/json
+*      responses:
+*        200:
+*         description: OK
+*         content:
+*          application/json:
+*            schema:
+*              type: object
+*/
 editorRouter.get('/exampleSuggestions', getExampleSuggestions);
-editorRouter.put('/exampleSuggestions/:id', putExampleSuggestion);
+
+/**
+* @swagger
+* /exampleSuggestions/{exampleSuggestionId}:
+*    get:
+*      description: Returns a single ExampleSuggestion object from the database
+*      tags:
+*       - development
+*      consumes:
+*        - application/json
+*      parameters:
+*        - in: path
+*          name: exampleSuggestionId
+*          required: true
+*          schema:
+*            type: string
+*          description: the exampleSuggestion id
+*      responses:
+*        200:
+*         description: OK
+*         content:
+*          application/json:
+*            schema:
+*              type: object
+*/
 editorRouter.get('/exampleSuggestions/:id', getExampleSuggestion);
 
 /**
- * @swagger
- * /genericWords:
- *   post:
- *     description: Populates the database with GenericWords using ig-en_normalized_expanded.json
- *     tags:
- *      - development
- *     consumes:
- *       - application/json
- *     responses:
- *      200:
- *         description: OK
- *   get:
- *     description: Gets all GenericWord objects from the database
- *     tags:
- *      - development
- *     consumes:
- *       - application/json
- *     responses:
- *      200:
- *         description: OK
- *
- * /genericWords/{genericWordId}:
- *   get:
- *     description: Returns a single GenericWord object from the database
- *     tags:
- *      - development
- *     consumes:
- *       - application/json
- *     parameters:
- *        - in: path
- *          name: genericWordId
- *          required: true
- *          schema:
- *            type: string
- *          description: the genericWord id
- *     responses:
- *      200:
- *         description: OK
- *
- *   put:
- *      description: Updates an existing GenericWord document
- *      tags:
- *       - development
- *      consumes:
- *        - application/json
- *      parameters:
- *       - in: path
- *         name: genericWordId
- *         required: true
- *         schema:
- *           type: string
- *         description: the genericWord id
- *       - in: body
- *         name: body
- *         description: The updated generic word data
- *         schema:
- *           type: object
- *           properties:
- *             id:
- *               type: string
- *             word:
- *               type: string
- *             wordClass:
- *               type: string
- *             definitions:
- *               type: array
- *               items:
- *                 type: string
- *             variations:
- *               type: array
- *               items:
- *                 type: string
- *      responses:
- *        200:
- *         description: OK
- *         content:
- *          application/json:
- *            schema:
- *              type: object
- */
+* @swagger
+* /exampleSuggestions/{exampleSuggestionId}:
+*    put:
+*      description: Updates and existing ExampleSuggestion document
+*      tags:
+*       - development
+*      consumes:
+*        - application/json
+*      parameters:
+*       - in: path
+*         name: exampleSuggestionId
+*         required: true
+*         schema:
+*           type: string
+*         description: the exampleSuggestion id
+*       - in: body
+*         name: body
+*         description: The updated example suggested data
+*         schema:
+*           type: object
+*           properties:
+*             id:
+*               type: string
+*             igbo:
+*               type: string
+*             english:
+*               type: string
+*             associatedWords:
+*               type: array
+*               items:
+*                 type: string
+*      responses:
+*        200:
+*         description: OK
+*         content:
+*          application/json:
+*            schema:
+*              type: object
+*/
+editorRouter.put('/exampleSuggestions/:id', putExampleSuggestion);
+
+/**
+* @swagger
+* /genericWords:
+*   post:
+*     description: Populates the database with GenericWords using ig-en_normalized_expanded.json
+*     tags:
+*      - development
+*     consumes:
+*       - application/json
+*     responses:
+*      200:
+*         description: OK
+*/
 editorRouter.post('/genericWords', createGenericWords);
-editorRouter.put('/genericWords/:id', putGenericWord);
+
+/**
+* @swagger
+* /genericWords:
+*   get:
+*     description: Gets all GenericWord objects from the database
+*     tags:
+*      - development
+*     consumes:
+*       - application/json
+*     responses:
+*      200:
+*         description: OK
+*/
 editorRouter.get('/genericWords', getGenericWords);
+
+/**
+* @swagger
+* /genericWords/{genericWordId}:
+*   get:
+*     description: Returns a single GenericWord object from the database
+*     tags:
+*      - development
+*     consumes:
+*       - application/json
+*     parameters:
+*        - in: path
+*          name: genericWordId
+*          required: true
+*          schema:
+*            type: string
+*          description: the genericWord id
+*     responses:
+*      200:
+*         description: OK
+*/
 editorRouter.get('/genericWords/:id', getGenericWord);
+
+/**
+* @swagger
+* /genericWords/{genericWordId}:
+*   put:
+*      description: Updates an existing GenericWord document
+*      tags:
+*       - development
+*      consumes:
+*        - application/json
+*      parameters:
+*       - in: path
+*         name: genericWordId
+*         required: true
+*         schema:
+*           type: string
+*         description: the genericWord id
+*       - in: body
+*         name: body
+*         description: The updated generic word data
+*         schema:
+*           type: object
+*           properties:
+*             id:
+*               type: string
+*             word:
+*               type: string
+*             wordClass:
+*               type: string
+*             definitions:
+*               type: array
+*               items:
+*                 type: string
+*             variations:
+*               type: array
+*               items:
+*                 type: string
+*      responses:
+*        200:
+*         description: OK
+*         content:
+*          application/json:
+*            schema:
+*              type: object
+*/
+editorRouter.put('/genericWords/:id', putGenericWord);
 
 export default editorRouter;

--- a/src/routers/editorRouter.js
+++ b/src/routers/editorRouter.js
@@ -5,7 +5,7 @@ import {
   postWordSuggestion,
   putWordSuggestion,
 } from '../controllers/wordSuggestions';
-import { putWord, postWord } from '../controllers/words';
+import { putWord, postWord, deleteWord } from '../controllers/words';
 import { putExample, postExample, getExamples } from '../controllers/examples';
 import {
   getExampleSuggestion,
@@ -563,5 +563,27 @@ editorRouter.get('/genericWords/:id', getGenericWord);
 *              type: object
 */
 editorRouter.put('/genericWords/:id', putGenericWord);
+
+/**
+* @swagger
+* /edit/words/{wordId}:
+*   delete:
+*     description: Deletes a word document from the production database
+*     tags:
+*      - development
+*     consumes:
+*       - application/json
+*     parameters:
+*        - in: path
+*          name: wordId
+*          required: true
+*          schema:
+*            type: string
+*          description: the word id
+*     responses:
+*       200:
+*         description: OK
+*/
+editorRouter.delete('/edit/words/:id', deleteWord);
 
 export default editorRouter;

--- a/src/routers/router.js
+++ b/src/routers/router.js
@@ -5,96 +5,105 @@ import { getExamples, getExample } from '../controllers/examples';
 const router = express.Router();
 
 /**
- * @swagger
- * /words:
- *   get:
- *     description: Get words in dictionary
- *     tags:
- *      - production
- *     parameters:
- *      - name: keyword
- *        description: keyword for querying words
- *        in: query
- *        required: false
- *        type: string
- *      - name: page
- *        description: page for results
- *        in: query
- *        required: false
- *        type: integer
- *      - name: range
- *        description: page for results using [x,y] syntax
- *        in: query
- *        required: false
- *        type: string
- *     responses:
- *      200:
- *         description: OK
- *
- * /words/{wordId}:
- *   get:
- *     description: Returns a single Word object from the database
- *     tags:
- *      - production
- *     consumes:
- *       - application/json
- *     parameters:
- *        - in: path
- *          name: wordId
- *          required: true
- *          schema:
- *            type: string
- *          description: the word id
- *     responses:
- *      200:
- *         description: OK
- *
- * /examples:
- *   get:
- *     description: Get examples in dictionary
-  *     tags:
- *      - production
- *     parameters:
- *      - name: keyword
- *        description: keyword for querying examples
- *        in: query
- *        required: false
- *        type: string
- *      - name: page
- *        description: page for results
- *        in: query
- *        required: false
- *        type: integer
- *      - name: range
- *        description: page for results using [x,y] syntax
- *        in: query
- *        required: false
- *        type: string
- *     responses:
- *      200:
- *         description: OK
- *
- * /examples/{exampleId}:
- *   get:
- *     description: Returns a single Example object from the database
- *     tags:
- *      - production
- *     consumes:
- *       - application/json
- *     parameters:
- *        - in: path
- *          name: exampleId
- *          required: true
- *          schema:
- *            type: string
- *          description: the example id
- *     responses:
- *      200:
- *         description: OK
- */
+* @swagger
+* /words:
+*   get:
+*     description: Get words in dictionary
+*     tags:
+*      - production
+*     parameters:
+*      - name: keyword
+*        description: keyword for querying words
+*        in: query
+*        required: false
+*        type: string
+*      - name: page
+*        description: page for results
+*        in: query
+*        required: false
+*        type: integer
+*      - name: range
+*        description: page for results using [x,y] syntax
+*        in: query
+*        required: false
+*        type: string
+*     responses:
+*      200:
+*         description: OK
+*/
 router.get('/words', getWords);
+
+/**
+* @swager
+* /words/{wordId}:
+*   get:
+*     description: Returns a single Word object from the database
+*     tags:
+*      - production
+*     consumes:
+*       - application/json
+*     parameters:
+*        - in: path
+*          name: wordId
+*          required: true
+*          schema:
+*            type: string
+*          description: the word id
+*     responses:
+*      200:
+*         description: OK
+*/
 router.get('/words/:id', getWord);
+
+/**
+* @swagger
+* /examples:
+*   get:
+*     description: Get examples in dictionary
+*     tags:
+*      - production
+*     parameters:
+*      - name: keyword
+*        description: keyword for querying examples
+*        in: query
+*        required: false
+*        type: string
+*      - name: page
+*        description: page for results
+*        in: query
+*        required: false
+*        type: integer
+*      - name: range
+*        description: page for results using [x,y] syntax
+*        in: query
+*        required: false
+*        type: string
+*     responses:
+*      200:
+*         description: OK
+*/
 router.get('/examples', getExamples);
+
+/**
+* @swagger
+* /examples/{exampleId}:
+*   get:
+*     description: Returns a single Example object from the database
+*     tags:
+*      - production
+*     consumes:
+*       - application/json
+*     parameters:
+*        - in: path
+*          name: exampleId
+*          required: true
+*          schema:
+*            type: string
+*          description: the example id
+*     responses:
+*      200:
+*         description: OK
+*/
 router.get('/examples/:id', getExample);
 
 export default router;


### PR DESCRIPTION
In this patch resolves #131. 

I completed two things:

1. the reorganized the documentation comments to align with the corresponding route. This will make it easier for anyone to understand the relationship between the comment/swagger documentation. While going through this documentation, I also noticed there was a missing GET /examples route. The function was already implemented, so I also added this route.

2. Added a new route `api/v1/edit/words/:id` to delete a word from mongodb. I also included documentation for this new route.

**Note**: I decided to return the word as a response when it is successfully deleted