### PR TITLE
Handle string representation of definitions

### DIFF
--- a/src/controllers/examples.js
+++ b/src/controllers/examples.js
@@ -1,5 +1,10 @@
 import mongoose from 'mongoose';
-import { assign, some } from 'lodash';
+import {
+  assign,
+  some,
+  map,
+  trim,
+} from 'lodash';
 import Example from '../models/Example';
 import { prepResponse, handleQueries, updateDocumentMerge } from './utils';
 import { findExampleSuggestionById } from './exampleSuggestions';
@@ -96,6 +101,10 @@ export const putExample = (req, res) => {
   if (!data.igbo && !data.english) {
     res.status(400);
     return res.send({ error: 'Required information is missing, double check your provided data' });
+  }
+
+  if (!Array.isArray(data.associatedWords)) {
+    data.associatedWords = map(data.associatedWords.split(','), (associatedWord) => trim(associatedWord));
   }
 
   if (some(data.associatedWords, (associatedWord) => !mongoose.Types.ObjectId.isValid(associatedWord))) {

--- a/src/controllers/genericWords.js
+++ b/src/controllers/genericWords.js
@@ -4,6 +4,7 @@ import {
   has,
   partial,
   map,
+  trim,
 } from 'lodash';
 import GenericWord from '../models/GenericWord';
 import testGenericWordsDictionary from '../../tests/__mocks__/genericWords.mock.json';
@@ -18,6 +19,10 @@ export const putGenericWord = (req, res) => {
   if (!every(REQUIRE_KEYS, partial(has, data))) {
     res.status(400);
     return res.send({ error: 'Required information is missing, double check your provided data' });
+  }
+
+  if (!Array.isArray(data.definitions)) {
+    data.definitions = map(data.definitions.split(','), (definition) => trim(definition));
   }
 
   return GenericWord.findById(id)
@@ -39,7 +44,7 @@ export const putGenericWord = (req, res) => {
 export const getGenericWords = (req, res) => {
   const { regexKeyword, page, sort } = handleQueries(req.query);
   return GenericWord
-    .find({ word: regexKeyword })
+    .find({ $or: [{ word: regexKeyword }, { definitions: regexKeyword }] })
     .sort({ approvals: 'desc' })
     .then((genericWords) => (
       prepResponse(res, genericWords, page, sort)

--- a/src/controllers/wordSuggestions.js
+++ b/src/controllers/wordSuggestions.js
@@ -4,6 +4,8 @@ import {
   every,
   has,
   partial,
+  map,
+  trim,
 } from 'lodash';
 import WordSuggestion from '../models/WordSuggestion';
 import { prepResponse, handleQueries } from './utils';
@@ -14,9 +16,13 @@ const REQUIRE_KEYS = ['word', 'wordClass', 'definitions'];
 export const postWordSuggestion = (req, res) => {
   const { body: data } = req;
 
-  if (!mongoose.Types.ObjectId.isValid(data.originalWordId)) {
+  if (data.originalWordId && !mongoose.Types.ObjectId.isValid(data.originalWordId)) {
     res.status(400);
     return res.send({ error: 'Invalid word id provided' });
+  }
+
+  if (!Array.isArray(data.definitions)) {
+    data.definitions = map(data.definitions.split(','), (definition) => trim(definition));
   }
 
   const newWordSuggestion = new WordSuggestion(data);
@@ -40,6 +46,10 @@ export const putWordSuggestion = (req, res) => {
   if (!every(REQUIRE_KEYS, partial(has, data))) {
     res.status(400);
     return res.send({ error: 'Required information is missing, double check your provided data' });
+  }
+
+  if (!Array.isArray(data.definitions)) {
+    data.definitions = map(data.definitions.split(','), (definition) => trim(definition));
   }
 
   return findWordSuggestionById(id)


### PR DESCRIPTION
If a list of definitions for any suggestion document is passed to the API as a comma delimited string, then the API should be able to parse that string and convert it into an array of definitions.