### PR TITLE
Igbo api 166/delete word suggestions

### DIFF
--- a/src/controllers/wordSuggestions.js
+++ b/src/controllers/wordSuggestions.js
@@ -100,3 +100,20 @@ export const getWordSuggestion = (req, res) => {
       return res.send({ error: 'An error has occurred while returning a single word suggestion' });
     });
 };
+
+/* Deletes a single WordSuggestion by using an id */
+export const deleteWordSuggestion = (req, res) => {
+  const { id } = req.params;
+  return WordSuggestion.findByIdAndDelete(id)
+    .then((wordSuggestion) => {
+      if (!wordSuggestion) {
+        res.status(400);
+        return res.send({ error: 'No word suggestion exists with teh provided id.' });
+      }
+      return res.send(wordSuggestion);
+    })
+    .catch(() => {
+      res.status(400);
+      return res.send({ error: 'An error has occurred while deleting and return a single word suggestion' });
+    });
+};

--- a/src/routers/editorRouter.js
+++ b/src/routers/editorRouter.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import {
+  deleteWordSuggestion,
   getWordSuggestion,
   getWordSuggestions,
   postWordSuggestion,
@@ -309,12 +310,33 @@ editorRouter.put('/examples/:id', putExample);
  *          application/json:
  *            schema:
  *              type: object
+ *   delete:
+ *      description: Deletes an existing WordSuggestion document
+ *      tags:
+ *       - development
+ *      consumes:
+ *        - application/json
+ *      parameters:
+ *       - in: path
+ *         name: wordSuggestionId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: the wordSuggestion id
+ *      responses:
+ *        200:
+ *         description: OK
+ *         content:
+ *          application/json:
+ *            schema:
+ *              type: object
  *
  */
 editorRouter.post('/wordSuggestions', postWordSuggestion);
 editorRouter.get('/wordSuggestions', getWordSuggestions);
 editorRouter.put('/wordSuggestions/:id', putWordSuggestion);
 editorRouter.get('/wordSuggestions/:id', getWordSuggestion);
+editorRouter.delete('/wordSuggestions/:id', deleteWordSuggestion);
 
 /**
  * @swagger

--- a/tests/__mocks__/documentData.js
+++ b/tests/__mocks__/documentData.js
@@ -3,6 +3,7 @@ import mongoose from 'mongoose';
 const { ObjectId } = mongoose.Types;
 
 const wordId = new ObjectId('5f864d7401203866b6546dd3');
+const wordSuggestionId = new ObjectId();
 const wordSuggestionData = {
   originalWordId: wordId,
   word: 'word',
@@ -104,6 +105,7 @@ const updatedGenericWordData = {
 };
 
 export {
+  wordSuggestionId,
   wordSuggestionData,
   wordSuggestionApprovedData,
   malformedWordSuggestionData,

--- a/tests/shared/commands.js
+++ b/tests/shared/commands.js
@@ -79,6 +79,12 @@ export const updateWordSuggestion = (id, data) => (
     .send(data)
 );
 
+export const deleteWordSuggestion = (id) => (
+  chai
+    .request(server)
+    .delete(`${API_ROUTE}/wordSuggestions/${id}`)
+);
+
 export const updateExampleSuggestion = (id, data) => (
   chai
     .request(server)

--- a/tests/wordSuggestions.test.js
+++ b/tests/wordSuggestions.test.js
@@ -5,12 +5,14 @@ import {
   isEqual,
 } from 'lodash';
 import {
+  deleteWordSuggestion,
   suggestNewWord,
   updateWordSuggestion,
   getWordSuggestions,
   getWordSuggestion,
 } from './shared/commands';
 import {
+  wordSuggestionId,
   wordSuggestionData,
   wordSuggestionApprovedData,
   malformedWordSuggestionData,
@@ -225,6 +227,35 @@ describe('MongoDB Word Suggestions', () => {
         .end((_, res) => {
           expect(res.status).to.equal(200);
           expectArrayIsInOrder(res.body, key);
+          done();
+        });
+    });
+  });
+
+  describe('/DELETE mongodb wordSuggestions', () => {
+    it('should delete a single word suggestion', (done) => {
+      suggestNewWord(wordSuggestionData)
+        .then((res) => {
+          expect(res.status).to.equal(200);
+          deleteWordSuggestion(res.body.id)
+            .then((result) => {
+              expect(result.status).to.equal(200);
+              expect(result.body.id).to.not.equal(undefined);
+              getWordSuggestion(result.body.id)
+                .end((_, resError) => {
+                  expect(resError.status).to.equal(400);
+                  expect(resError.body.error).to.not.equal(undefined);
+                  done();
+                });
+            });
+        });
+    });
+
+    it('should return error for non existent word suggestion', (done) => {
+      getWordSuggestion(wordSuggestionId)
+        .end((_, res) => {
+          expect(res.status).to.equal(400);
+          expect(res.body.error).to.not.equal(undefined);
           done();
         });
     });


### PR DESCRIPTION
This exposes a new DELETE route for `WordSuggestion` documents with the route `api/v1/wordSuggestions/:id`