### PR TITLE
Update Merge routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean": "rm -rf node_modules/ build/ yarn.lock package-lock.json *.log",
     "dev": "npm-run-all -p start:database start:server",
     "mongodump": "rm -rf dump/ && mongodump -d igbo_api -o dump",
-    "mocha": "NODE_ENV=test mocha -r esm ./tests",
+    "mocha": "NODE_ENV=test mocha --timeout 10000 -r esm ./tests",
     "precommit": "lint-staged",
     "prestart:database": "[ ! -d \"./db\" ] && mkdir ./db || echo 'Database directory exists'",
     "start": "node ./build/server.js",

--- a/src/controllers/exampleSuggestions.js
+++ b/src/controllers/exampleSuggestions.js
@@ -20,7 +20,7 @@ export const postExampleSuggestion = (req, res) => {
   const newExampleSuggestion = new ExampleSuggestion(data);
   return newExampleSuggestion.save()
     .then((exampleSuggestion) => (
-      res.send({ id: exampleSuggestion.id })
+      res.send(exampleSuggestion)
     ))
     .catch(() => {
       res.status(400);

--- a/src/controllers/examples.js
+++ b/src/controllers/examples.js
@@ -52,7 +52,7 @@ export const getExample = (req, res) => {
 
 /* Merges new data into an existing Example document */
 const mergeIntoExample = ({ data, exampleSuggestion }) => (
-  findExampleById(data.id)
+  findExampleById(data.originalExampleId)
     .then((example) => {
       if (!example) {
         throw new Error('Example doesn\'t exist');
@@ -63,9 +63,6 @@ const mergeIntoExample = ({ data, exampleSuggestion }) => (
       }
       return updatedExample.save();
     })
-    .catch(() => {
-      throw new Error('An error occurred while merging into an existing example.');
-    })
 );
 
 /* Creates a new Example document from an existing ExampleSuggestion document */
@@ -75,7 +72,7 @@ const createExampleFromSuggestion = ({ data, exampleSuggestion }) => (
       if (exampleSuggestion) {
         updateDocumentMerge(exampleSuggestion, example.id);
       }
-      return { id: example.id };
+      return example;
     })
     .catch(() => {
       throw new Error('An error occurred while saving the new example.');
@@ -113,11 +110,13 @@ export const mergeExample = async (req, res) => {
 
   try {
     if (data.originalExampleId) {
-      return res.send(mergeIntoExample({ data, exampleSuggestion }));
+      const result = await mergeIntoExample({ data, exampleSuggestion });
+      return res.send(result);
     }
-    return res.send(createExampleFromSuggestion({ data, exampleSuggestion }));
+    const result = await createExampleFromSuggestion({ data, exampleSuggestion });
+    return res.send(result);
   } catch (error) {
-    res.send(400);
+    res.status(400);
     return res.send({ error: error.message });
   }
 };

--- a/src/controllers/wordSuggestions.js
+++ b/src/controllers/wordSuggestions.js
@@ -28,7 +28,7 @@ export const postWordSuggestion = (req, res) => {
   const newWordSuggestion = new WordSuggestion(data);
   return newWordSuggestion.save()
     .then((wordSuggestion) => (
-      res.send({ id: wordSuggestion.id })
+      res.send(wordSuggestion)
     ))
     .catch(() => {
       res.status(400);

--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -124,7 +124,7 @@ export const createWord = async (data) => {
 
 /* Merges new data into an existing Word document */
 const mergeIntoWord = ({ data, genericWord, wordSuggestion }) => (
-  findWordById(data.id)
+  findWordById(data.originalWordID)
     .then((word) => {
       if (!word) {
         throw new Error('Word doesn\'t exist');
@@ -136,10 +136,11 @@ const mergeIntoWord = ({ data, genericWord, wordSuggestion }) => (
       if (wordSuggestion) {
         updateDocumentMerge(wordSuggestion, word.id);
       }
-      return updatedWord.save();
+      updatedWord.save();
+      return updatedWord;
     })
-    .catch(() => {
-      throw new Error('An error occurred while merging into an existing word.');
+    .catch((error) => {
+      throw new Error(error.message);
     })
 );
 
@@ -153,7 +154,7 @@ const createWordFromSuggestion = ({ data, genericWord, wordSuggestion }) => (
       if (wordSuggestion) {
         updateDocumentMerge(wordSuggestion, word.id);
       }
-      return { id: word.id };
+      return word;
     })
     .catch(() => {
       throw new Error('An error occurred while saving the new word.');
@@ -197,11 +198,13 @@ export const mergeWord = async (req, res) => {
 
   try {
     if (data.originalWordId) {
-      return res.send(mergeIntoWord({ data, genericWord, wordSuggestion }));
+      const result = await mergeIntoWord({ data, genericWord, wordSuggestion });
+      return res.send(result);
     }
-    return res.send(createWordFromSuggestion({ data, genericWord, wordSuggestion }));
+    const result = await createWordFromSuggestion({ data, genericWord, wordSuggestion });
+    return res.send(result);
   } catch (error) {
-    res.send(400);
+    res.status(400);
     return res.send({ error: error.message });
   }
 };

--- a/src/models/ExampleSuggestion.js
+++ b/src/models/ExampleSuggestion.js
@@ -3,7 +3,7 @@ import { toJSONPlugin } from './plugins';
 
 const { Schema, Types } = mongoose;
 const exampleSuggestionSchema = new Schema({
-  originalExampleId: { type: Types.ObjectId, ref: 'Example' },
+  originalExampleId: { type: Types.ObjectId, ref: 'Example', default: null },
   igbo: { type: String, default: '' },
   english: { type: String, default: '' },
   associatedWords: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },

--- a/src/models/WordSuggestion.js
+++ b/src/models/WordSuggestion.js
@@ -3,7 +3,7 @@ import { toJSONPlugin } from './plugins';
 
 const { Schema, Types } = mongoose;
 const wordSuggestionSchema = new Schema({
-  originalWordId: { type: Types.ObjectId, ref: 'Word' },
+  originalWordId: { type: Types.ObjectId, ref: 'Word', default: null },
   word: { type: String, required: true },
   wordClass: { type: String, required: true },
   definitions: {

--- a/src/routers/editorRouter.js
+++ b/src/routers/editorRouter.js
@@ -6,8 +6,8 @@ import {
   postWordSuggestion,
   putWordSuggestion,
 } from '../controllers/wordSuggestions';
-import { putWord, postWord } from '../controllers/words';
-import { putExample, postExample } from '../controllers/examples';
+import { putWord, mergeWord } from '../controllers/words';
+import { putExample, mergeExample } from '../controllers/examples';
 import {
   getExampleSuggestion,
   getExampleSuggestions,
@@ -24,9 +24,9 @@ import {
 const editorRouter = express.Router();
 
 /* These routes are used to allow users to suggest new words and examples */
-editorRouter.post('/words', postWord);
+editorRouter.post('/words', mergeWord);
 editorRouter.put('/words/:id', putWord);
-editorRouter.post('/examples', postExample);
+editorRouter.post('/examples', mergeExample);
 editorRouter.put('/examples/:id', putExample);
 
 editorRouter.post('/wordSuggestions', postWordSuggestion);

--- a/swagger.json
+++ b/swagger.json
@@ -218,8 +218,8 @@
         }
       },
       "post": {
-        "summary": "Creates a new Word document",
-        "description": "Creates a new Word document",
+        "summary": "Creates a new Word document via merging",
+        "description": "Merges an existing WordSuggestion or GenericWord document into either an existing Word document or create a new Word document",
         "tags": ["Development"],
         "parameters": [
           {
@@ -340,8 +340,8 @@
         }
       },
       "post": {
-        "summary": "Creates a new Example document",
-        "description": "Creates a new Example document",
+        "summary": "Creates a new Example document via merging",
+        "description": "Merges an existing ExampleSuggestion document into either an existing Example document or create a new Example document",
         "tags": ["Development"],
         "parameters": [
           {

--- a/swagger.json
+++ b/swagger.json
@@ -26,13 +26,6 @@
     }
   ],
   "definitions": {
-    "id": {
-      "properties": {
-        "id": {
-          "type": "string"
-        }
-      }
-    },
     "word": {
       "properties": {
         "word": {
@@ -235,7 +228,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/id"
+              "$ref": "#/definitions/word"
             }
           }
         }
@@ -261,7 +254,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/id"
+              "$ref": "#/definitions/word"
             }
           }
         }
@@ -357,7 +350,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/id"
+              "$ref": "#/definitions/example"
             }
           }
         }
@@ -383,7 +376,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/id"
+              "$ref": "#/definitions/example"
             }
           }
         }
@@ -479,7 +472,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/id"
+              "$ref": "#/definitions/wordSuggestion"
             }
           }
         }
@@ -625,7 +618,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/id"
+              "$ref": "#/definitions/exampleSuggestion"
             }
           }
         }

--- a/tests/__mocks__/documentData.js
+++ b/tests/__mocks__/documentData.js
@@ -5,7 +5,6 @@ const { ObjectId } = mongoose.Types;
 const wordId = new ObjectId('5f864d7401203866b6546dd3');
 const wordSuggestionId = new ObjectId();
 const wordSuggestionData = {
-  originalWordId: wordId,
   word: 'word',
   wordClass: 'wordClass',
   definitions: ['first'],

--- a/tests/api-json.test.js
+++ b/tests/api-json.test.js
@@ -22,7 +22,7 @@ describe('JSON Dictionary', function () {
       populateAPI(),
       populateGenericWordsAPI(),
     ]).then(() => {
-      setTimeout(done, 20000);
+      setTimeout(done, 30000);
     });
   });
 

--- a/tests/api-json.test.js
+++ b/tests/api-json.test.js
@@ -4,13 +4,28 @@ import { isEqual } from 'lodash';
 import mongoose from 'mongoose';
 import server from '../src/server';
 import { NO_PROVIDED_TERM } from '../src/shared/constants/errorMessages';
-import { searchTerm } from './shared/commands';
+import { LONG_TIMEOUT } from './shared/constants';
+import {
+  populateAPI,
+  populateGenericWordsAPI,
+  searchTerm,
+} from './shared/commands';
 
 const { expect } = chai;
 
 chai.use(chaiHttp);
 
-describe('JSON Dictionary', () => {
+describe('JSON Dictionary', function () {
+  this.timeout(LONG_TIMEOUT);
+  before((done) => {
+    Promise.all([
+      populateAPI(),
+      populateGenericWordsAPI(),
+    ]).then(() => {
+      setTimeout(done, 20000);
+    });
+  });
+
   describe('/GET words', () => {
     it('should return back word information', (done) => {
       const keyword = 'agụū';

--- a/tests/examples.test.js
+++ b/tests/examples.test.js
@@ -162,7 +162,7 @@ describe('MongoDB Examples', () => {
         });
     });
 
-    it('should return one word', (done) => {
+    it('should return one example', (done) => {
       getExamples()
         .then((res) => {
           getExample(res.body[0].id)
@@ -175,7 +175,7 @@ describe('MongoDB Examples', () => {
         });
     });
 
-    it('should return an error for incorrect word id', (done) => {
+    it('should return an error for incorrect example id', (done) => {
       getExamples()
         .then(() => {
           getExample(NONEXISTENT_ID)

--- a/tests/examples.test.js
+++ b/tests/examples.test.js
@@ -29,16 +29,52 @@ describe('MongoDB Examples', () => {
     it('should create a new example in the database', (done) => {
       suggestNewExample(exampleSuggestionData)
         .then((res) => {
+          expect(res.status).to.equal(200);
           const mergingExampleSuggestion = { ...res.body, ...exampleSuggestionData };
           createExample(mergingExampleSuggestion)
             .then((result) => {
               expect(result.status).to.equal(200);
               expect(result.body.id).to.not.equal(undefined);
-              getExampleSuggestion(res.body.id)
-                .end((_, exampleRes) => {
-                  expect(exampleRes.status).to.equal(200);
-                  expect(result.body.id).to.equal(exampleRes.body.merged);
-                  done();
+              getExample(result.body.id)
+                .then((updatedExampleRes) => {
+                  expect(updatedExampleRes.status).to.equal(200);
+                  getExampleSuggestion(res.body.id)
+                    .end((_, exampleRes) => {
+                      expect(exampleRes.status).to.equal(200);
+                      expect(updatedExampleRes.body.igbo).to.equal(exampleRes.body.igbo);
+                      expect(updatedExampleRes.body.english).to.equal(exampleRes.body.english);
+                      expect(updatedExampleRes.body.id).to.equal(exampleRes.body.merged);
+                      done();
+                    });
+                });
+            });
+        });
+    });
+
+    it('should merge into an existing example', (done) => {
+      suggestNewExample(exampleSuggestionData)
+        .then((res) => {
+          expect(res.status).to.equal(200);
+          getExamples()
+            .then((examplesRes) => {
+              const firstExample = examplesRes.body[0];
+              const mergingExampleSuggestion = { ...res.body, originalExampleId: firstExample.id };
+              createExample(mergingExampleSuggestion)
+                .then((result) => {
+                  expect(result.status).to.equal(200);
+                  expect(result.body.id).to.not.equal(undefined);
+                  getExample(result.body.id)
+                    .then((updatedExampleRes) => {
+                      expect(updatedExampleRes.status).to.equal(200);
+                      getExampleSuggestion(res.body.id)
+                        .end((_, exampleRes) => {
+                          expect(exampleRes.status).to.equal(200);
+                          expect(updatedExampleRes.body.igbo).to.equal(exampleRes.body.igbo);
+                          expect(updatedExampleRes.body.english).to.equal(exampleRes.body.english);
+                          expect(updatedExampleRes.body.id).to.equal(exampleRes.body.merged);
+                          done();
+                        });
+                    });
                 });
             });
         });

--- a/tests/genericWords.test.js
+++ b/tests/genericWords.test.js
@@ -127,7 +127,7 @@ describe('MongoDB Generic Words', () => {
         });
     });
 
-    it('should return an error for incorrect word id', (done) => {
+    it('should return an error for incorrect generic word id', (done) => {
       getGenericWords()
         .then(() => {
           getGenericWord(NONEXISTENT_ID)

--- a/tests/genericWords.test.js
+++ b/tests/genericWords.test.js
@@ -6,13 +6,11 @@ import {
   some,
 } from 'lodash';
 import {
-  populateGenericWordsAPI,
   getGenericWords,
   getGenericWord,
   updateGenericWord,
 } from './shared/commands';
 import {
-  LONG_TIMEOUT,
   GENERIC_WORD_KEYS,
   INVALID_ID,
   NONEXISTENT_ID,
@@ -23,13 +21,6 @@ import { genericWordApprovedData, malformedGenericWordData, updatedGenericWordDa
 const { expect } = chai;
 
 describe('MongoDB Generic Words', () => {
-  before(function (done) {
-    this.timeout(LONG_TIMEOUT);
-    populateGenericWordsAPI().then(() => {
-      setTimeout(done, 5000);
-    });
-  });
-
   describe('/PUT mongodb genericWords', () => {
     it('should update specific genericWord with provided data', (done) => {
       getGenericWords()

--- a/tests/shared/constants.js
+++ b/tests/shared/constants.js
@@ -7,6 +7,7 @@ export const TEST_ROUTE = '/api/v1/test';
 export const WORD_KEYS = ['variations', 'definitions', 'stems', 'examples', 'id', 'normalized', 'word', 'wordClass'];
 export const EXAMPLE_KEYS = ['igbo', 'english', 'associatedWords', 'id'];
 export const EXAMPLE_SUGGESTION_KEYS = [
+  'originalExampleId',
   'igbo',
   'english',
   'associatedWords',

--- a/tests/shared/constants.js
+++ b/tests/shared/constants.js
@@ -1,6 +1,6 @@
 import mongoose from 'mongoose';
 
-export const LONG_TIMEOUT = 30000;
+export const LONG_TIMEOUT = 60000;
 export const API_ROUTE = '/api/v1';
 export const TEST_ROUTE = '/api/v1/test';
 


### PR DESCRIPTION
The merge routes weren't actually converting `WordSuggestion`, `ExampleSuggestion`, and `GenericWord` documents into either `Word` or `Example` documents. This PR fixes this issue alongside introduces more tests.