### PR TITLE
Igbo api 201/per page query

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean": "rm -rf node_modules/ build/ yarn.lock package-lock.json *.log",
     "dev": "npm-run-all -p start:database start:server",
     "mongodump": "rm -rf dump/ && mongodump -d igbo_api -o dump",
-    "mocha": "NODE_ENV=test mocha --timeout 10000 -r esm ./tests",
+    "mocha": "NODE_ENV=test mocha --timeout 60000 -r esm ./tests",
     "precommit": "lint-staged",
     "prestart:database": "[ ! -d \"./db\" ] && mkdir ./db || echo 'Database directory exists'",
     "start": "node ./build/server.js",

--- a/src/controllers/exampleSuggestions.js
+++ b/src/controllers/exampleSuggestions.js
@@ -54,12 +54,12 @@ export const putExampleSuggestion = (req, res) => {
 
 /* Returns all existing ExampleSuggestion objects */
 export const getExampleSuggestions = (req, res) => {
-  const { regexKeyword, page, sort } = handleQueries(req.query);
+  const { regexKeyword, ...rest } = handleQueries(req.query);
   return ExampleSuggestion
     .find({ $or: [{ igbo: regexKeyword }, { english: regexKeyword }] })
     .sort({ approvals: 'desc' })
     .then((exampleSuggestions) => (
-      prepResponse(res, exampleSuggestions, page, sort)
+      prepResponse({ res, docs: exampleSuggestions, ...rest })
     ))
     .catch(() => {
       res.status(400);

--- a/src/controllers/examples.js
+++ b/src/controllers/examples.js
@@ -23,10 +23,10 @@ const searchExamples = (regex) => (
 
 /* Returns examples from MongoDB */
 export const getExamples = async (req, res) => {
-  const { regexKeyword, page, sort } = handleQueries(req.query);
+  const { regexKeyword, ...rest } = handleQueries(req.query);
   const examples = await searchExamples(regexKeyword);
 
-  return prepResponse(res, examples, page, sort);
+  return prepResponse({ res, docs: examples, ...rest });
 };
 
 export const findExampleById = (id) => (

--- a/src/controllers/genericWords.js
+++ b/src/controllers/genericWords.js
@@ -42,12 +42,12 @@ export const putGenericWord = (req, res) => {
 
 /* Returns all existing GenericWord objects */
 export const getGenericWords = (req, res) => {
-  const { regexKeyword, page, sort } = handleQueries(req.query);
+  const { regexKeyword, ...rest } = handleQueries(req.query);
   return GenericWord
     .find({ $or: [{ word: regexKeyword }, { definitions: regexKeyword }] })
     .sort({ approvals: 'desc' })
     .then((genericWords) => (
-      prepResponse(res, genericWords, page, sort)
+      prepResponse({ res, docs: genericWords, ...rest })
     ))
     .catch(() => {
       res.status(400);

--- a/src/controllers/utils/index.js
+++ b/src/controllers/utils/index.js
@@ -3,7 +3,8 @@ import { assign, orderBy } from 'lodash';
 import removePrefix from '../../shared/utils/removePrefix';
 import createRegExp from '../../shared/utils/createRegExp';
 
-const RESPONSE_LIMIT = 10;
+const DEFAULT_RESPONSE_LIMIT = 10;
+const MAX_RESPONSE_LIMIT = 25;
 
 /* Either creates a regex pattern for provided searchWord
 or fallbacks to matching every word */
@@ -19,15 +20,31 @@ export const sortDocsByDefinitions = (searchWord, docs) => {
   return docs;
 };
 
+/* Validates the provided range */
+const isValidRange = (range) => {
+  const validRange = range;
+  validRange[1] += 1;
+  return !(validRange[1] - validRange[0] > MAX_RESPONSE_LIMIT) && !(validRange[1] - validRange[0] < 0);
+};
+
 /* Wrapper function to prep response by limiting number of docs return to the client */
-export const paginate = (res, docs, page) => {
+export const paginate = (res, docs, page, range) => {
   res.setHeader('Content-Range', docs.length);
-  return docs.slice(page * RESPONSE_LIMIT, RESPONSE_LIMIT * (page + 1));
+  if (Array.isArray(range) && isValidRange(range)) {
+    return docs.slice(...range);
+  }
+  return docs.slice(page * DEFAULT_RESPONSE_LIMIT, DEFAULT_RESPONSE_LIMIT * (page + 1));
 };
 
 /* Preps response with sorting and paginating */
-export const prepResponse = (res, docs, page, sort) => {
-  const tenDocs = paginate(res, docs, page);
+export const prepResponse = ({
+  res,
+  docs,
+  page,
+  sort,
+  range,
+}) => {
+  const tenDocs = paginate(res, docs, page, range);
   return res.send(orderBy(tenDocs, [sort.key], [sort.direction]));
 };
 
@@ -42,13 +59,13 @@ const convertFilterToKeyword = (filter = '{"word": ""}') => {
   }
 };
 
-/* Converts the range query into a number to be used as the page query */
-const convertRangeToPage = (range = '[0,10]') => {
+/* Parses the ranges query to turn into an array */
+const parseRange = (range) => {
   try {
-    const parsedRange = typeof range === 'object' ? range : JSON.parse(range) || [0, 10];
-    return parseInt(parsedRange[0], 10) || 0;
+    const parsedRange = typeof range === 'object' ? range : JSON.parse(range) || null;
+    return parsedRange;
   } catch {
-    return 0;
+    return null;
   }
 };
 
@@ -75,20 +92,22 @@ export const handleQueries = (query = {}) => {
   const {
     keyword = '',
     page: pageQuery = '',
-    range,
+    range: rangeQuery = '',
     sort: sortQuery,
     filter: filterQuery,
   } = query;
   const filter = convertFilterToKeyword(filterQuery);
   const searchWord = removePrefix(keyword || filter || '');
   const regexKeyword = createQueryRegex(searchWord);
-  const page = parseInt(pageQuery, 10) || convertRangeToPage(range) || 0;
+  const page = parseInt(pageQuery, 10) || 0;
+  const range = parseRange(rangeQuery) || 0;
   const sort = parseSortKeys(sortQuery);
   return {
     searchWord,
     regexKeyword,
     page,
     sort,
+    range,
   };
 };
 

--- a/src/controllers/wordSuggestions.js
+++ b/src/controllers/wordSuggestions.js
@@ -69,12 +69,12 @@ export const putWordSuggestion = (req, res) => {
 
 /* Returns all existing WordSuggestion objects */
 export const getWordSuggestions = (req, res) => {
-  const { regexKeyword, page, sort } = handleQueries(req.query);
+  const { regexKeyword, ...rest } = handleQueries(req.query);
   WordSuggestion
     .find({ word: regexKeyword })
     .sort({ approvals: 'desc' })
     .then((wordSuggestions) => (
-      prepResponse(res, wordSuggestions, page, sort)
+      prepResponse({ res, docs: wordSuggestions, ...rest })
     ))
     .catch(() => {
       res.status(400);

--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -58,15 +58,25 @@ export const getWords = async (req, res) => {
     searchWord,
     regexKeyword,
     page,
-    sort,
+    ...rest
   } = handleQueries(req.query);
   const words = await searchWordUsingIgbo(regexKeyword);
 
   if (!words.length) {
     const englishWords = await getWordsUsingEnglish(regexKeyword, searchWord, page);
-    return prepResponse(res, englishWords, page, sort);
+    return prepResponse({
+      res,
+      docs: englishWords,
+      page,
+      ...rest,
+    });
   }
-  return prepResponse(res, words, page, sort);
+  return prepResponse({
+    res,
+    docs: words,
+    page,
+    ...rest,
+  });
 };
 
 /* Returns a word from MongoDB using an id */

--- a/swagger.json
+++ b/swagger.json
@@ -192,7 +192,7 @@
           },
           {
             "name": "range",
-            "description": "Page for result using [x,y] syntax",
+            "description": "Page for result using [x,y] syntax, max range includes 25 documents",
             "in": "query",
             "required": false,
             "type": "string"
@@ -314,7 +314,7 @@
           },
           {
             "name": "range",
-            "description": "Page for result using [x,y] syntax",
+            "description": "Page for result using [x,y] syntax, max range includes 25 documents",
             "in": "query",
             "required": false,
             "type": "string"
@@ -436,7 +436,7 @@
           },
           {
             "name": "range",
-            "description": "Page for result using [x,y] syntax",
+            "description": "Page for result using [x,y] syntax, max range includes 25 documents",
             "in": "query",
             "required": false,
             "type": "string"
@@ -582,7 +582,7 @@
           },
           {
             "name": "range",
-            "description": "Page for result using [x,y] syntax",
+            "description": "Page for result using [x,y] syntax, max range includes 25 documents",
             "in": "query",
             "required": false,
             "type": "string"
@@ -728,7 +728,7 @@
           },
           {
             "name": "range",
-            "description": "Page for result using [x,y] syntax",
+            "description": "Page for result using [x,y] syntax, max range includes 25 documents",
             "in": "query",
             "required": false,
             "type": "string"
@@ -855,7 +855,7 @@
           },
           {
             "name": "range",
-            "description": "Page for result using [x,y] syntax",
+            "description": "Page for result using [x,y] syntax, max range includes 25 documents",
             "in": "query",
             "required": false,
             "type": "string"

--- a/tests/api-json.test.js
+++ b/tests/api-json.test.js
@@ -4,7 +4,6 @@ import { isEqual } from 'lodash';
 import mongoose from 'mongoose';
 import server from '../src/server';
 import { NO_PROVIDED_TERM } from '../src/shared/constants/errorMessages';
-import { LONG_TIMEOUT } from './shared/constants';
 import {
   populateAPI,
   populateGenericWordsAPI,
@@ -15,8 +14,7 @@ const { expect } = chai;
 
 chai.use(chaiHttp);
 
-describe('JSON Dictionary', function () {
-  this.timeout(LONG_TIMEOUT);
+describe('JSON Dictionary', () => {
   before((done) => {
     Promise.all([
       populateAPI(),

--- a/tests/examples.test.js
+++ b/tests/examples.test.js
@@ -9,7 +9,6 @@ import {
   getExampleSuggestion,
 } from './shared/commands';
 import {
-  LONG_TIMEOUT,
   EXAMPLE_KEYS,
   INVALID_ID,
   NONEXISTENT_ID,
@@ -196,13 +195,12 @@ describe('MongoDB Examples', () => {
         });
     });
 
-    it('should return at most ten example per request with range query', function (done) {
-      this.timeout(LONG_TIMEOUT);
+    it('should return at most ten example per request with range query', (done) => {
       Promise.all([
         getExamples({ range: '[0,9]' }),
         getExamples({ range: [10, 19] }),
         getExamples({ range: '[20,29]' }),
-        getExamples({ range: '[30,39' }),
+        getExamples({ range: '[30,39]' }),
       ]).then((res) => {
         expectUniqSetsOfResponses(res);
         done();
@@ -220,12 +218,12 @@ describe('MongoDB Examples', () => {
       });
     });
 
-    it('should return prioritize page over range', (done) => {
+    it('should return prioritize range over page', (done) => {
       Promise.all([
         getExamples({ page: '1' }),
         getExamples({ page: '1', range: '[100,109]' }),
       ]).then((res) => {
-        expect(isEqual(res[0].body, res[1].body)).to.equal(true);
+        expect(isEqual(res[0].body, res[1].body)).to.equal(false);
         done();
       });
     });

--- a/tests/genericWords.test.js
+++ b/tests/genericWords.test.js
@@ -148,12 +148,59 @@ describe('MongoDB Generic Words', () => {
         });
     });
 
+    it('should return at most twenty five generic words per request with range query', (done) => {
+      Promise.all([
+        getGenericWords({ range: true }),
+        getGenericWords({ range: '[10,34]' }),
+        getGenericWords({ range: '[35,59]' }),
+      ]).then((res) => {
+        expectUniqSetsOfResponses(res, 25);
+        done();
+      });
+    });
+
+    it('should return at most four generic words per request with range query', (done) => {
+      getGenericWords({ range: '[5,8]' })
+        .end((_, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body).to.have.lengthOf.at.most(4);
+          done();
+        });
+    });
+
+    it('should return at most ten generic words because of a large range', (done) => {
+      getGenericWords({ range: '[10,40]' })
+        .end((_, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body).to.have.lengthOf.at.most(10);
+          done();
+        });
+    });
+
+    it('should return at most ten generic words because of a tiny range', (done) => {
+      getGenericWords({ range: '[10,9]' })
+        .end((_, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body).to.have.lengthOf.at.most(10);
+          done();
+        });
+    });
+
+    it('should return at most ten generic words because of an invalid', (done) => {
+      getGenericWords({ range: 'incorrect' })
+        .end((_, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body).to.have.lengthOf.at.most(10);
+          done();
+        });
+    });
+
     it('should return different sets of generic words for pagination', (done) => {
       Promise.all([
         getGenericWords({ range: '[0,9]' }),
         getGenericWords({ range: [10, 19] }),
         getGenericWords({ range: '[20,29]' }),
-        getGenericWords({ range: '[30,39' }),
+        getGenericWords({ range: '[30,39]' }),
       ]).then((res) => {
         expectUniqSetsOfResponses(res);
         done();
@@ -171,12 +218,12 @@ describe('MongoDB Generic Words', () => {
       });
     });
 
-    it('should return prioritize page over range', (done) => {
+    it('should return prioritize range over page', (done) => {
       Promise.all([
         getGenericWords({ page: '1' }),
         getGenericWords({ page: '1', range: '[100,109]' }),
       ]).then((res) => {
-        expect(isEqual(res[0].body, res[1].body)).to.equal(true);
+        expect(isEqual(res[0].body, res[1].body)).to.equal(false);
         done();
       });
     });

--- a/tests/parse.test.js
+++ b/tests/parse.test.js
@@ -4,7 +4,6 @@ import rimraf from 'rimraf';
 import { keys, isEqual } from 'lodash';
 import { DICTIONARIES_DIR } from '../src/shared/constants/parseFileLocations';
 import replaceAbbreviations from '../src/shared/utils/replaceAbbreviations';
-import { LONG_TIMEOUT } from './shared/constants';
 import { searchTerm, searchMockedTerm } from './shared/commands';
 
 const { expect } = chai;
@@ -14,8 +13,7 @@ if (!fs.existsSync(mocksDir)) {
 }
 
 describe('Parse', () => {
-  describe('Dictionaries', function () {
-    this.timeout(LONG_TIMEOUT);
+  describe('Dictionaries', () => {
     it('should create dictionaries', (done) => {
       import('../src/dictionaries/buildDictionaries')
         .then(() => {

--- a/tests/shared/constants.js
+++ b/tests/shared/constants.js
@@ -1,6 +1,5 @@
 import mongoose from 'mongoose';
 
-export const LONG_TIMEOUT = 60000;
 export const API_ROUTE = '/api/v1';
 export const TEST_ROUTE = '/api/v1/test';
 

--- a/tests/shared/utils.js
+++ b/tests/shared/utils.js
@@ -8,10 +8,10 @@ import {
 
 const { expect } = chai;
 
-const expectUniqSetsOfResponses = (res) => {
+const expectUniqSetsOfResponses = (res, responseLength = 10) => {
   forEach(res, (docsRes, index) => {
     expect(docsRes.status).to.equal(200);
-    expect(docsRes.body).to.have.lengthOf.at.most(10);
+    expect(docsRes.body).to.have.lengthOf.at.most(responseLength);
     if (index !== 0) {
       const prevDocsIds = map(res[index].body, ({ id }) => ({ id }));
       const currentDocsIds = map(docsRes.body, ({ id }) => ({ id }));


### PR DESCRIPTION
No longer handles the `pageQuery`. Instead, the functionality for the `range` query is expanded. Now a consumer of the API is able to specify how many items (within a range) they want to get back from the database. The max number of documents that can be returned from the database is 25.

Closes #201 