### PR TITLE
Update the updatedOn field for documents

### DIFF
--- a/src/models/ExampleSuggestion.js
+++ b/src/models/ExampleSuggestion.js
@@ -1,5 +1,5 @@
 import mongoose from 'mongoose';
-import { toJSONPlugin, toObjectPlugin } from './plugins';
+import { toJSONPlugin, toObjectPlugin, updatedOnHook } from './plugins';
 
 const { Schema, Types } = mongoose;
 const exampleSuggestionSchema = new Schema({
@@ -18,5 +18,6 @@ const exampleSuggestionSchema = new Schema({
 }, { toObject: toObjectPlugin });
 
 toJSONPlugin(exampleSuggestionSchema);
+updatedOnHook(exampleSuggestionSchema);
 
 export default mongoose.model('ExampleSuggestion', exampleSuggestionSchema);

--- a/src/models/GenericWord.js
+++ b/src/models/GenericWord.js
@@ -1,5 +1,5 @@
 import mongoose from 'mongoose';
-import { toJSONPlugin, toObjectPlugin } from './plugins';
+import { toJSONPlugin, toObjectPlugin, updatedOnHook } from './plugins';
 
 const { Schema, Types } = mongoose;
 const genericWordSchema = new Schema({
@@ -20,6 +20,7 @@ const genericWordSchema = new Schema({
 }, { toObject: toObjectPlugin });
 
 toJSONPlugin(genericWordSchema);
+updatedOnHook(genericWordSchema);
 
 genericWordSchema.pre('findOneAndDelete', async function (next) {
   const genericWord = await this.model.findOne(this.getQuery());

--- a/src/models/WordSuggestion.js
+++ b/src/models/WordSuggestion.js
@@ -1,6 +1,6 @@
 /* eslint-disable prefer-arrow-callback */
 import mongoose from 'mongoose';
-import { toJSONPlugin, toObjectPlugin } from './plugins';
+import { toJSONPlugin, toObjectPlugin, updatedOnHook } from './plugins';
 
 const { Schema, Types } = mongoose;
 const wordSuggestionSchema = new Schema({
@@ -22,6 +22,7 @@ const wordSuggestionSchema = new Schema({
 }, { toObject: toObjectPlugin });
 
 toJSONPlugin(wordSuggestionSchema);
+updatedOnHook(wordSuggestionSchema);
 
 wordSuggestionSchema.pre('findOneAndDelete', async function (next) {
   const wordSuggestion = await this.model.findOne(this.getQuery());

--- a/src/models/plugins/index.js
+++ b/src/models/plugins/index.js
@@ -27,3 +27,10 @@ export const toObjectPlugin = ({
     delete ret.__v;
   },
 });
+
+export const updatedOnHook = (schema) => (
+  schema.pre('save', function () {
+    this.updatedOn = Date.now();
+    return this;
+  })
+);

--- a/tests/exampleSuggestions.test.js
+++ b/tests/exampleSuggestions.test.js
@@ -114,6 +114,20 @@ describe('MongoDB Example Suggestions', () => {
           done();
         });
     });
+
+    it('should update the updatedOn field', (done) => {
+      getExampleSuggestions()
+        .then((exampleSuggestionsRes) => {
+          expect(exampleSuggestionsRes.status).to.equal(200);
+          const exampleSuggestion = exampleSuggestionsRes.body[0];
+          updateExampleSuggestion(exampleSuggestion.id, exampleSuggestion)
+            .end((_, res) => {
+              expect(res.status).to.equal(200);
+              expect(Date.parse(exampleSuggestion.updatedOn)).to.be.lessThan(Date.parse(res.body.updatedOn));
+              done();
+            });
+        });
+    });
   });
 
   describe('/GET mongodb exampleSuggestions', () => {

--- a/tests/genericWords.test.js
+++ b/tests/genericWords.test.js
@@ -67,6 +67,20 @@ describe('MongoDB Generic Words', () => {
           done();
         });
     });
+
+    it('should update the updatedOn field', (done) => {
+      getGenericWords()
+        .then((genericWordsRes) => {
+          expect(genericWordsRes.status).to.equal(200);
+          const genericWord = genericWordsRes.body[0];
+          updateGenericWord(genericWord.id, { ...genericWord, word: 'updated' })
+            .end((_, res) => {
+              expect(res.status).to.equal(200);
+              expect(Date.parse(genericWord.updatedOn)).to.be.lessThan(Date.parse(res.body.updatedOn));
+              done();
+            });
+        });
+    });
   });
 
   describe('/GET mongodb genericWords', () => {

--- a/tests/wordSuggestions.test.js
+++ b/tests/wordSuggestions.test.js
@@ -215,6 +215,20 @@ describe('MongoDB Word Suggestions', () => {
           done();
         });
     });
+
+    it('should update the updatedOn field', (done) => {
+      getWordSuggestions()
+        .then((wordSuggestionsRes) => {
+          expect(wordSuggestionsRes.status).to.equal(200);
+          const wordSuggestion = wordSuggestionsRes.body[0];
+          updateWordSuggestion(wordSuggestion.id, { ...wordSuggestion, word: 'updated' })
+            .end((_, res) => {
+              expect(res.status).to.equal(200);
+              expect(Date.parse(wordSuggestion.updatedOn)).to.be.lessThan(Date.parse(res.body.updatedOn));
+              done();
+            });
+        });
+    });
   });
 
   describe('/GET mongodb wordSuggestions', () => {


### PR DESCRIPTION
Documents have an `updatedOn` field that didn't accurately capture when a `wordSuggestion`, `exampleSuggestion`, or even a `genericWord` document was updated in the database.

This PR fixes that problem by defining the pre `save` hook that gets called whenever a document is about to get saved to the database.

Closes #228 