### PR TITLE
Igbo api 223/textareas for definitions

### DIFF
--- a/cypress/integration/example.spec.js
+++ b/cypress/integration/example.spec.js
@@ -1,3 +1,5 @@
+import { reduce } from 'lodash';
+
 describe('Example', () => {
   beforeEach(() => {
     cy.server();
@@ -57,6 +59,29 @@ describe('Example', () => {
       cy.get('button').contains('Back to Form').click();
       cy.get('[data-test="igbo-input"]');
       cy.get('[data-test="english-input"]');
+    });
+
+    it('constructs the correct object shape to send to the server', () => {
+      const igbo = 'igbo';
+      const english = 'english';
+      const email = 'test@example.com';
+      cy.route({
+        method: 'POST',
+        url: '/api/v1/exampleSuggestions',
+        response: { id: 'success' },
+        status: 200,
+      }).as('postExampleSuggestion');
+      cy.get('[data-test="igbo-input"]').type(igbo);
+      cy.get('[data-test="english-input"]').type(english);
+      cy.get('[data-test="email-input').type(email);
+      cy.get('form[data-test="example-form"]').then((res) => {
+        const formData = reduce(res.serializeArray(), (builtFormData, { name, value }) => (
+          { ...builtFormData, [name]: value }
+        ), {});
+        expect(formData.igbo).to.equal(igbo);
+        expect(formData.english).to.equal(english);
+        expect(formData.email).to.equal(email);
+      });
     });
   });
 });

--- a/cypress/integration/word.spec.js
+++ b/cypress/integration/word.spec.js
@@ -1,3 +1,4 @@
+import { reduce } from 'lodash';
 import wordsResponse from '../support/constants';
 
 describe('Word', () => {
@@ -174,6 +175,38 @@ describe('Word', () => {
       cy.get('[data-test="select-actions"]').first().click();
       cy.contains('Create an Example').click();
       cy.get('[data-test="suggestion-modal"]');
+    });
+
+    it('constructs the correct object shape to send to the server', () => {
+      const word = 'word';
+      const wordClass = 'wordClass';
+      const definition = 'firstDefinition';
+      const variation = 'firstVariation';
+      const email = 'test@example.com';
+      cy.route({
+        method: 'POST',
+        url: '/api/v1/wordSuggestions',
+        response: { id: 'success' },
+        status: 200,
+      }).as('postWordSuggestion');
+      cy.get('[data-test="add-button"]').click();
+      cy.get('[data-test="new-word-input"]').type(word);
+      cy.get('[data-test="word-class-input"]').type(wordClass);
+      cy.get('[aria-label="Add Definition"]').click();
+      cy.get('[data-test="definitions-0-input"]').type(definition);
+      cy.get('[aria-label="Add Variation"]').click();
+      cy.get('[data-test="variations-0-input"]').type(variation);
+      cy.get('[data-test="email-input"]').type(email);
+      cy.get('form[data-test="word-form"]').then((res) => {
+        const formData = reduce(res.serializeArray(), (builtFormData, { name, value }) => (
+          { ...builtFormData, [name]: value }
+        ), {});
+        expect(formData.word).to.equal(word);
+        expect(formData.wordClass).to.equal(wordClass);
+        expect(formData['definitions[0]']).to.include(definition);
+        expect(formData['variations[0]']).to.include(variation);
+        expect(formData.email).to.equal(email);
+      });
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "test": "start-server-and-test develop http://localhost:8000 cypress:open",
-    "test:run": "start-server-and-test develop http://localhost:8000 cypress:run"
+    "test:run": "yarn build && start-server-and-test develop http://localhost:8000 cypress:run"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "react-hook-form": "^6.9.6",
     "react-modal": "^3.11.2",
     "start-server-and-test": "^1.11.5",
-    "tailwindcss": "^1.8.12"
+    "tailwindcss": "^1.8.12",
+    "urlencode": "^1.1.0"
   },
   "devDependencies": {
     "cypress": "^5.3.0",

--- a/src/API.js
+++ b/src/API.js
@@ -1,4 +1,6 @@
 import axios from 'axios';
-import { WORDS_API_URL } from './config';
+import { WORDS_API_URL, WORD_SUGGESTIONS_API_URL, EXAMPLE_SUGGESTIONS_API_URL } from './config';
 
-export default (lastSearch, page = 0) => axios.get(`${WORDS_API_URL}?keyword=${lastSearch}&page=${page}`);
+export const getWord = (lastSearch, page = 0) => axios.get(`${WORDS_API_URL}?keyword=${lastSearch}&page=${page}`);
+export const postWordSuggestion = (data) => axios.post(WORD_SUGGESTIONS_API_URL, data);
+export const postExampleSuggestion = (data) => axios.post(EXAMPLE_SUGGESTIONS_API_URL, data);

--- a/src/components/Email.js
+++ b/src/components/Email.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Controller } from 'react-hook-form';
+
+const Email = ({ defaultValues, getValues, control }) => (
+  <>
+    <h2 className="form-header">Email</h2>
+    <p className="mb-4">You will be sent email notifications concerning the status of your suggestion.</p>
+    <Controller
+      as={(
+        <input
+          type="email"
+          className="form-input"
+          placeholder="Email"
+          data-test="email-input"
+        />
+      )}
+      name="email"
+      control={control}
+      defaultValue={defaultValues?.english || getValues().english}
+    />
+  </>
+);
+
+Email.propTypes = {
+  defaultValues: PropTypes.objectOf(['email']),
+  getValues: PropTypes.func,
+  control: PropTypes.objectOf(['mode']),
+};
+
+Email.defaultProps = {
+  defaultValues: { email: '' },
+  getValues: () => {},
+  control: null,
+};
+
+export default Email;

--- a/src/forms/AddExample.js
+++ b/src/forms/AddExample.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import axios from 'axios';
-import { map, compact, trim } from 'lodash';
 import { useForm, Controller } from 'react-hook-form';
-import { EXAMPLE_SUGGESTIONS_API_URL } from '../config';
+import Email from '../components/Email';
+import { postExampleSuggestion } from '../API';
 
 const AddExample = ({
   onRequestClose,
@@ -22,12 +21,9 @@ const AddExample = ({
   const onSubmit = (data) => {
     const cleanedData = {
       ...data,
-      definitions: compact(map(data.definitions, (definition) => trim(definition))),
-      variations: compact(map(data.variations, (variation) => trim(variation))),
-      originalWordId: defaultValues?.id || null,
+      associatedWords: defaultValues?.id ? [defaultValues?.id] : [],
     };
-    axios
-      .post(EXAMPLE_SUGGESTIONS_API_URL, cleanedData)
+    postExampleSuggestion(cleanedData)
       .then(() => {
         reset();
         onSuccess({ subtitle: 'You\'re example has been sent for review by editors.' });
@@ -38,7 +34,7 @@ const AddExample = ({
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form data-test="example-form" onSubmit={handleSubmit(onSubmit)}>
       <p className="mt-2">
         By suggesting a new example, you are helping in advancing learning materials for the Igbo language.
       </p>
@@ -79,6 +75,7 @@ const AddExample = ({
         control={control}
         defaultValue={defaultValues?.english || getValues().english}
       />
+      <Email defaultValues={defaultValues} getValues={getValues} control={control} />
       <div className="flex flex-col items-start lg:items-end">
         <div className="flex flex-col w-full lg:flex-row-reverse lg:justify-start">
           <button type="submit" className="button primary-button">Submit</button>

--- a/src/forms/AddWord.js
+++ b/src/forms/AddWord.js
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import axios from 'axios';
 import { map, compact, trim } from 'lodash';
 import { useForm, Controller } from 'react-hook-form';
-import { WORD_SUGGESTIONS_API_URL } from '../config';
 import AddIcon from '../assets/icons/add.svg';
 import DeleteIcon from '../assets/icons/delete.svg';
+import Email from '../components/Email';
+import { postWordSuggestion } from '../API';
 
 const AddWord = ({
   onRequestClose,
@@ -30,8 +30,7 @@ const AddWord = ({
       variations: compact(map(data.variations, (variation) => trim(variation))),
       originalWordId: defaultValues?.id || null,
     };
-    axios
-      .post(WORD_SUGGESTIONS_API_URL, cleanedData)
+    postWordSuggestion(cleanedData)
       .then(() => {
         reset();
         onSuccess({ subtitle: 'You\'re word edit has been sent for review by editors.' });
@@ -42,7 +41,7 @@ const AddWord = ({
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form data-test="word-form" onSubmit={handleSubmit(onSubmit)}>
       <p className="mt-2">
         {`By either suggesting a new word or editing an existing one, 
         you are helping in advancing learning materials for the Igbo language.`}
@@ -105,8 +104,8 @@ const AddWord = ({
             </h3>
             <Controller
               as={(
-                <input
-                  className="form-input"
+                <textarea
+                  className="form-textarea"
                   size="large"
                   placeholder="Definition"
                   defaultValue={definition}
@@ -188,6 +187,7 @@ const AddWord = ({
           <p className="text-gray-600">No variations</p>
         </div>
       )}
+      <Email defaultValues={defaultValues} getValues={getValues} control={control} />
       <div className="flex flex-col items-start lg:items-end">
         <div className="flex flex-col w-full lg:flex-row-reverse lg:justify-start">
           <button type="submit" className="button primary-button">Submit</button>

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -8,7 +8,7 @@ import Word from '../components/Word';
 import Modal from '../components/Modal';
 import AddWord from '../forms/AddWord';
 import getWord from '../API';
-import parseQueries from './utils';
+import parseQueries from '../utils/parseQueries';
 
 const search = ({ location, navigate }) => {
   const [queries, setQueries] = useState(location?.search ? parseQueries(location.search) : {});

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -7,7 +7,7 @@ import NoWord from '../components/NoWord';
 import Word from '../components/Word';
 import Modal from '../components/Modal';
 import AddWord from '../forms/AddWord';
-import getWord from '../API';
+import { getWord } from '../API';
 import parseQueries from '../utils/parseQueries';
 
 const search = ({ location, navigate }) => {
@@ -44,7 +44,7 @@ const search = ({ location, navigate }) => {
    */
   const handlePagination = async (page) => {
     const searchWordRoute = `/search?word=${queries.word}&page=${page}`;
-    navigate(searchWordRoute, { state: 'ij' });
+    navigate(searchWordRoute);
     setRoute(searchWordRoute);
   };
 

--- a/src/pages/word.js
+++ b/src/pages/word.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { map } from 'lodash';
-import getWord from '../API';
+import { getWord } from '../API';
 import Navbar from '../components/Navbar';
 import NoWord from '../components/NoWord';
 import Modal from '../components/Modal';

--- a/src/pages/word.js
+++ b/src/pages/word.js
@@ -8,7 +8,7 @@ import Select from '../components/Select';
 import SearchBar from '../components/SearchBar';
 import AddWord from '../forms/AddWord';
 import AddExample from '../forms/AddExample';
-import parseQueries from './utils';
+import parseQueries from '../utils/parseQueries';
 
 const word = ({ location }) => {
   const queries = location?.search ? parseQueries(location.search) : {};

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -71,6 +71,17 @@ h1 {
   @apply py-5;
 }
 
+.form-textarea {
+  @apply w-full;
+  @apply border-current;
+  @apply border-solid;
+  @apply border;
+  @apply border-gray-600;
+  @apply rounded-md;
+  @apply px-3;
+  @apply py-2;
+}
+
 .list-container {
   @apply flex;
   @apply items-center;

--- a/src/utils/parseQueries.js
+++ b/src/utils/parseQueries.js
@@ -1,12 +1,13 @@
 /* Takes the query string and transform it into an object */
-const parseQueries = (search) => (
-  search
+const parseQueries = (queries) => {
+  const queriesMap = queries
     .split(/(\?|&)/)
     .filter((query) => query !== '' && query !== '?' && query !== '&')
     .reduce((queryMap, query) => {
       const keyValuePair = query.split('=');
       return { ...queryMap, [keyValuePair[0]]: keyValuePair[1] };
-    }, {})
-);
+    }, {});
+  return queriesMap;
+};
 
 export default parseQueries;

--- a/src/utils/parseQueries.js
+++ b/src/utils/parseQueries.js
@@ -1,3 +1,4 @@
+import urlencode from 'urlencode';
 /* Takes the query string and transform it into an object */
 const parseQueries = (queries) => {
   const queriesMap = queries
@@ -5,7 +6,7 @@ const parseQueries = (queries) => {
     .filter((query) => query !== '' && query !== '?' && query !== '&')
     .reduce((queryMap, query) => {
       const keyValuePair = query.split('=');
-      return { ...queryMap, [keyValuePair[0]]: keyValuePair[1] };
+      return { ...queryMap, [keyValuePair[0]]: urlencode.decode(keyValuePair[1]) };
     }, {});
   return queriesMap;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7331,7 +7331,7 @@ hyphenate-style-name@^1.0.3:
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"
   integrity sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==
 
-iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24:
+iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@~0.4.11:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -13452,6 +13452,13 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+urlencode@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/urlencode/-/urlencode-1.1.0.tgz#1f2ba26f013c85f0133f7a3ad6ff2730adf7cbb7"
+  integrity sha1-HyuibwE8hfATP3o61v8nMK33y7c=
+  dependencies:
+    iconv-lite "~0.4.11"
 
 urql@^1.9.7:
   version "1.10.1"


### PR DESCRIPTION
The `input` elements are now `textarea` elements to make it easier for users to edit long definitions.
There's also a new `Email` component responsible for rendering the email field within both the `addWord` and `addExample` components.

Closes #223 
Closes #219 