### PR TITLE
Igbo api 239/invalid queries

### DIFF
--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #Get current date
-NOW="$(date +'%d-%m-%Y_%H-%M')"
+NOW="$(date +'%m-%d-%Y_%H-%M')"
 
 # Path to a temporary directory
 DIR=./igbo_api_db

--- a/src/controllers/examples.js
+++ b/src/controllers/examples.js
@@ -31,22 +31,27 @@ const searchExamples = ({ query, skip, limit }) => (
 
 /* Returns examples from MongoDB */
 export const getExamples = async (req, res) => {
-  const {
-    regexKeyword,
-    skip,
-    limit,
-    ...rest
-  } = handleQueries(req.query);
-  const regexMatch = searchExamplesRegexQuery(regexKeyword);
-  const examples = await searchExamples({ query: regexMatch, skip, limit });
+  try {
+    const {
+      regexKeyword,
+      skip,
+      limit,
+      ...rest
+    } = handleQueries(req.query);
+    const regexMatch = searchExamplesRegexQuery(regexKeyword);
+    const examples = await searchExamples({ query: regexMatch, skip, limit });
 
-  return packageResponse({
-    res,
-    docs: examples,
-    model: Example,
-    query: regexMatch,
-    ...rest,
-  });
+    return packageResponse({
+      res,
+      docs: examples,
+      model: Example,
+      query: regexMatch,
+      ...rest,
+    });
+  } catch (err) {
+    res.status(400);
+    return res.send({ error: err.message });
+  }
 };
 
 export const findExampleById = (id) => (

--- a/src/shared/constants/sortingDirections.js
+++ b/src/shared/constants/sortingDirections.js
@@ -1,0 +1,4 @@
+export default {
+  ASCENDING: 'asc',
+  DESCENDING: 'desc',
+};

--- a/tests/exampleSuggestions.test.js
+++ b/tests/exampleSuggestions.test.js
@@ -20,6 +20,7 @@ import {
 } from './__mocks__/documentData';
 import { EXAMPLE_SUGGESTION_KEYS, INVALID_ID } from './shared/constants';
 import { expectUniqSetsOfResponses, expectArrayIsInOrder } from './shared/utils';
+import SortingDirections from '../src/shared/constants/sortingDirections';
 
 const { expect } = chai;
 
@@ -188,7 +189,7 @@ describe('MongoDB Example Suggestions', () => {
         getExampleSuggestions()
           .end((_, res) => {
             expect(res.status).to.equal(200);
-            expectArrayIsInOrder(res.body, 'approvals', 'desc');
+            expectArrayIsInOrder(res.body, 'approvals', SortingDirections.DESCENDING);
             done();
           });
       });
@@ -246,11 +247,11 @@ describe('MongoDB Example Suggestions', () => {
         });
     });
 
-    it('should return at most ten example suggestions because of an invalid', (done) => {
+    it('should throw an error due to an invalid range', (done) => {
       getExampleSuggestions({ range: 'incorrect' })
         .end((_, res) => {
-          expect(res.status).to.equal(200);
-          expect(res.body).to.have.lengthOf.at.most(10);
+          expect(res.status).to.equal(400);
+          expect(res.body.error).to.not.equal(undefined);
           done();
         });
     });
@@ -269,9 +270,9 @@ describe('MongoDB Example Suggestions', () => {
 
     it('should return different sets of example suggestions for pagination', (done) => {
       Promise.all([
-        getExampleSuggestions(0),
-        getExampleSuggestions(1),
-        getExampleSuggestions(2),
+        getExampleSuggestions({ page: 0 }),
+        getExampleSuggestions({ page: 1 }),
+        getExampleSuggestions({ page: 2 }),
       ]).then((res) => {
         expectUniqSetsOfResponses(res);
         done();
@@ -290,8 +291,8 @@ describe('MongoDB Example Suggestions', () => {
 
     it('should return a descending sorted list of example suggestions with sort query', (done) => {
       const key = 'word';
-      const direction = 'desc';
-      getExampleSuggestions({ sort: `["${key}": "${direction}"]` })
+      const direction = SortingDirections.DESCENDING;
+      getExampleSuggestions({ sort: `["${key}", "${direction}"]` })
         .end((_, res) => {
           expect(res.status).to.equal(200);
           expectArrayIsInOrder(res.body, key, direction);
@@ -301,8 +302,8 @@ describe('MongoDB Example Suggestions', () => {
 
     it('should return an ascending sorted list of example suggestions with sort query', (done) => {
       const key = 'definitions';
-      const direction = 'asc';
-      getExampleSuggestions({ sort: `["${key}": "${direction}"]` })
+      const direction = SortingDirections.ASCENDING;
+      getExampleSuggestions({ sort: `["${key}", "${direction}"]` })
         .end((_, res) => {
           expect(res.status).to.equal(200);
           expectArrayIsInOrder(res.body, key, direction);
@@ -310,12 +311,22 @@ describe('MongoDB Example Suggestions', () => {
         });
     });
 
-    it('should return ascending sorted list of example suggestions with malformed sort query', (done) => {
+    it('should throw an error due to malformed sort query', (done) => {
       const key = 'wordClass';
       getExampleSuggestions({ sort: `["${key}]` })
         .end((_, res) => {
-          expect(res.status).to.equal(200);
-          expectArrayIsInOrder(res.body, key);
+          expect(res.status).to.equal(400);
+          expect(res.body.error).to.not.equal(undefined);
+          done();
+        });
+    });
+
+    it('should throw an error due to invalid sorting ordering', (done) => {
+      const key = 'igbo';
+      getExampleSuggestions({ sort: `["${key}", "invalid"]` })
+        .end((_, res) => {
+          expect(res.status).to.equal(400);
+          expect(res.body.error).to.not.equal(undefined);
           done();
         });
     });

--- a/tests/examples.test.js
+++ b/tests/examples.test.js
@@ -1,5 +1,6 @@
 import chai from 'chai';
 import { isEqual, forIn, some } from 'lodash';
+import SortingDirections from '../src/shared/constants/sortingDirections';
 import {
   createExample,
   getExamples,
@@ -209,9 +210,9 @@ describe('MongoDB Examples', () => {
 
     it('should return different sets of example suggestions for pagination', (done) => {
       Promise.all([
-        getExamples(0),
-        getExamples(1),
-        getExamples(2),
+        getExamples({ page: 0 }),
+        getExamples({ page: 1 }),
+        getExamples({ page: 2 }),
       ]).then((res) => {
         expectUniqSetsOfResponses(res);
         done();
@@ -230,8 +231,8 @@ describe('MongoDB Examples', () => {
 
     it('should return a descending sorted list of examples with sort query', (done) => {
       const key = 'igbo';
-      const direction = 'desc';
-      getExamples({ sort: `["${key}": "${direction}"]` })
+      const direction = SortingDirections.DESCENDING;
+      getExamples({ sort: `["${key}", "${direction}"]` })
         .end((_, res) => {
           expect(res.status).to.equal(200);
           expectArrayIsInOrder(res.body, key, direction);
@@ -241,8 +242,8 @@ describe('MongoDB Examples', () => {
 
     it('should return an ascending sorted list of examples with sort query', (done) => {
       const key = 'english';
-      const direction = 'asc';
-      getExamples({ sort: `["${key}": "${direction}"]` })
+      const direction = SortingDirections.ASCENDING;
+      getExamples({ sort: `["${key}", "${direction}"]` })
         .end((_, res) => {
           expect(res.status).to.equal(200);
           expectArrayIsInOrder(res.body, key, direction);
@@ -250,12 +251,22 @@ describe('MongoDB Examples', () => {
         });
     });
 
-    it('should return ascending sorted list of examples with malformed sort query', (done) => {
+    it('should throw an error due to malformed sort query', (done) => {
       const key = 'igbo';
       getExamples({ sort: `["${key}]` })
         .end((_, res) => {
-          expect(res.status).to.equal(200);
-          expectArrayIsInOrder(res.body, key);
+          expect(res.status).to.equal(400);
+          expect(res.body.error).to.not.equal(undefined);
+          done();
+        });
+    });
+
+    it('should throw an error due to invalid sorting ordering', (done) => {
+      const key = 'igbo';
+      getExamples({ sort: `["${key}", "invalid"]` })
+        .end((_, res) => {
+          expect(res.status).to.equal(400);
+          expect(res.body.error).to.not.equal(undefined);
           done();
         });
     });

--- a/tests/shared/utils.js
+++ b/tests/shared/utils.js
@@ -5,6 +5,7 @@ import {
   map,
   every,
 } from 'lodash';
+import SortingDirections from '../../src/shared/constants/sortingDirections';
 
 const { expect } = chai;
 
@@ -20,13 +21,13 @@ const expectUniqSetsOfResponses = (res, responseLength = 10) => {
   });
 };
 
-const expectArrayIsInOrder = (array, key, direction = 'asc') => {
+const expectArrayIsInOrder = (array, key, direction = SortingDirections.ASCENDING) => {
   const isOrdered = every(map(array, (item) => item[key]), (value, index) => {
     if (index === 0) {
       return true;
     }
     return (
-      direction === 'asc'
+      direction === SortingDirections.ASCENDING
         ? String(array[index - 1][key] <= String(value))
         : String(array[index - 1][key] >= String(value))
     );


### PR DESCRIPTION
The API was too lenient with incorrectly formatted queries. If a consumer of the API accidentally forgot to close the `range` query with the `]` character, the API would handle that for the consumer without notifying them they provided an incorrectly formatted query.

Also, the `sync.sh` script tar file naming convention had days before months. The new tar file names will have months before days.

Now the API will return an error message if the consumer doesn't follow the expected query syntax. 
Closes #239 