### PR TITLE
Igbo api 244/remove doc type

### DIFF
--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -190,11 +190,7 @@ const createWordFromSuggestion = (suggestionDoc) => (
  * new Word document or merges into an existing Word document */
 export const mergeWord = async (req, res) => {
   const { body: data } = req;
-  const suggestionDoc = data.docType === SuggestionTypes.WORD_SUGGESTIONS
-    ? await findWordSuggestionById(data.id)
-    : data.docType === SuggestionTypes.GENERIC_WORDS
-      ? await findGenericWordById(data.id)
-      : null;
+  const suggestionDoc = (await findWordSuggestionById(data.id)) || (await findGenericWordById(data.id));
 
   if (!suggestionDoc) {
     res.status(400);

--- a/src/shared/constants/suggestionTypes.js
+++ b/src/shared/constants/suggestionTypes.js
@@ -1,6 +1,4 @@
 export default {
   WORD: 'word',
   EXAMPLE: 'example',
-  WORD_SUGGESTIONS: 'wordSuggestions',
-  GENERIC_WORDS: 'genericWords',
 };

--- a/tests/api-mongo.test.js
+++ b/tests/api-mongo.test.js
@@ -21,7 +21,6 @@ import {
   INVALID_MESSAGE,
 } from './shared/constants';
 import SortingDirections from '../src/shared/constants/sortingDirections';
-import SuggestionTypes from '../src/shared/constants/suggestionTypes';
 import {
   wordSuggestionData,
   updatedWordData,
@@ -86,7 +85,7 @@ describe('MongoDB Words', () => {
         .then((res) => {
           expect(res.status).to.equal(200);
           const mergingWordSuggestion = { ...res.body, ...updatedWordSuggestionData };
-          createWord(mergingWordSuggestion)
+          createWord(mergingWordSuggestion.id)
             .then((result) => {
               expect(result.status).to.equal(200);
               expect(result.body.id).to.not.equal(undefined);
@@ -115,7 +114,7 @@ describe('MongoDB Words', () => {
           updateGenericWord(firstGenericWord.id, firstGenericWord)
             .then((saveMergedGenericWord) => {
               expect(saveMergedGenericWord.status).to.equal(200);
-              createWord({ id: firstGenericWord.id, docType: SuggestionTypes.GENERIC_WORDS })
+              createWord(firstGenericWord.id)
                 .then((result) => {
                   expect(result.status).to.equal(200);
                   expect(result.body.id).to.not.equal(undefined);
@@ -138,7 +137,7 @@ describe('MongoDB Words', () => {
           expect(res.status).to.equal(200);
           const firstGenericWord = res.body[0];
           delete firstGenericWord.word;
-          createWord(firstGenericWord)
+          createWord(firstGenericWord.id)
             .end((_, result) => {
               expect(result.status).to.equal(400);
               expect(result.body.error).to.not.equal(undefined);
@@ -155,7 +154,7 @@ describe('MongoDB Words', () => {
             .then((wordRes) => {
               const firstWord = wordRes.body[0];
               const mergingWordSuggestion = { ...res.body, originalExampleId: firstWord.id };
-              createWord(mergingWordSuggestion)
+              createWord(mergingWordSuggestion.id)
                 .then((result) => {
                   expect(result.status).to.equal(200);
                   expect(result.body.id).to.not.equal(undefined);
@@ -185,7 +184,7 @@ describe('MongoDB Words', () => {
           updateGenericWord(firstGenericWord.id, firstGenericWord)
             .then((updatedGenericWordRes) => {
               expect(updatedGenericWordRes.status).to.equal(200);
-              createWord({ id: updatedGenericWordRes.body.id, docType: SuggestionTypes.GENERIC_WORDS })
+              createWord(updatedGenericWordRes.body.id)
                 .then((wordRes) => {
                   expect(wordRes.status).to.equal(200);
                   expect(wordRes.body.word).to.equal(updatedGenericWordRes.body.word);
@@ -214,7 +213,7 @@ describe('MongoDB Words', () => {
                 wordClass: 'wordClass',
                 originalWordId: firstWord.id,
               };
-              createWord({ id: mergingGenericWord.id, docType: SuggestionTypes.GENERIC_WORDS })
+              createWord(mergingGenericWord.id)
                 .end((_, result) => {
                   expect(result.status).to.equal(400);
                   expect(result.body.error).to.not.equal(undefined);
@@ -237,7 +236,7 @@ describe('MongoDB Words', () => {
     it('should return a newly created word after merging with just an id', (done) => {
       suggestNewWord(wordSuggestionData)
         .then((res) => {
-          createWord({ id: res.body.id })
+          createWord(res.body.id)
             .end((_, result) => {
               expect(result.status).to.equal(200);
               expect(result.body.error).to.equal(undefined);
@@ -250,7 +249,7 @@ describe('MongoDB Words', () => {
       suggestNewWord(wordSuggestionData)
         .then((res) => {
           const mergingWordSuggestion = { ...res.body, ...wordSuggestionData };
-          createWord(mergingWordSuggestion)
+          createWord(mergingWordSuggestion.id)
             .then((result) => {
               expect(result.status).to.equal(200);
               expect(result.body.id).to.not.equal(undefined);
@@ -270,7 +269,7 @@ describe('MongoDB Words', () => {
       suggestNewWord(wordSuggestionData)
         .then((res) => {
           const mergingWordSuggestion = { ...res.body, ...wordSuggestionData };
-          createWord(mergingWordSuggestion)
+          createWord(mergingWordSuggestion.id)
             .then((result) => {
               expect(result.status).to.equal(200);
               expect(result.body.id).to.not.equal(undefined);

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -97,7 +97,7 @@ describe('Auth', () => {
     });
 
     it('should forbid an editor from creating a word', (done) => {
-      createWord({}, { role: 'editor' })
+      createWord('', { role: 'editor' })
         .end((_, res) => {
           expect(res.status).to.equal(403);
           expect(res.body.error).to.not.equal(undefined);
@@ -106,7 +106,7 @@ describe('Auth', () => {
     });
 
     it('should forbid an editor from creating an example', (done) => {
-      createExample({}, { role: 'editor' })
+      createExample('', { role: 'editor' })
         .end((_, res) => {
           expect(res.status).to.equal(403);
           expect(res.body.error).to.not.equal(undefined);

--- a/tests/editing-flow.test.js
+++ b/tests/editing-flow.test.js
@@ -24,7 +24,6 @@ import {
   wordSuggestionData,
   wordSuggestionWithNestedExampleSuggestionData,
 } from './__mocks__/documentData';
-import SuggestionTypes from '../src/shared/constants/suggestionTypes';
 import { SAVE_DOC_DELAY } from './shared/constants';
 
 const { expect } = chai;
@@ -34,7 +33,7 @@ describe('Editing Flow', () => {
     suggestNewWord(wordSuggestionData)
       .then((wordSuggestionRes) => {
         expect(wordSuggestionRes.status).to.equal(200);
-        createWord(wordSuggestionRes.body)
+        createWord(wordSuggestionRes.body.id)
           .then((mergedWordRes) => {
             expect(mergedWordRes.status).to.equal(200);
             getWordSuggestion(wordSuggestionRes.body.id)
@@ -59,7 +58,7 @@ describe('Editing Flow', () => {
     suggestNewWord(genericWordData)
       .then((genericWordRes) => {
         expect(genericWordRes.status).to.equal(200);
-        createWord(genericWordRes.body)
+        createWord(genericWordRes.body.id)
           .then((mergedWordRes) => {
             expect(mergedWordRes.status).to.equal(200);
             getWordSuggestion(genericWordRes.body.id)
@@ -84,7 +83,7 @@ describe('Editing Flow', () => {
     suggestNewWord(wordSuggestionWithNestedExampleSuggestionData)
       .then((wordSuggestionRes) => {
         expect(wordSuggestionRes.status).to.equal(200);
-        createWord(wordSuggestionRes.body)
+        createWord(wordSuggestionRes.body.id)
           .then((mergedWordRes) => {
             expect(mergedWordRes.status).to.equal(200);
             setTimeout(() => {
@@ -114,12 +113,12 @@ describe('Editing Flow', () => {
   it('should add a new associatedWordId to exampleSuggestion', (done) => {
     suggestNewWord(wordSuggestionData)
       .then((res) => {
-        createWord(res.body)
+        createWord(res.body.id)
           .then((firstWordRes) => {
             suggestNewWord(wordSuggestionWithNestedExampleSuggestionData)
               .then((wordSuggestionRes) => {
                 expect(wordSuggestionRes.status).to.equal(200);
-                createWord(wordSuggestionRes.body)
+                createWord(wordSuggestionRes.body.id)
                   .then((mergedWordRes) => {
                     expect(mergedWordRes.status).to.equal(200);
                     setTimeout(() => {
@@ -134,7 +133,7 @@ describe('Editing Flow', () => {
                           suggestNewExample(newExampleSuggestion)
                             .then((exampleSuggestionRes) => {
                               expect(exampleSuggestionRes.status).to.equal(200);
-                              createExample(exampleSuggestionRes.body)
+                              createExample(exampleSuggestionRes.body.id)
                                 .end((_, finalRes) => {
                                   expect(isEqual(
                                     exampleSuggestionRes.body.associatedWords,
@@ -170,7 +169,7 @@ describe('Editing Flow', () => {
     suggestNewWord(genericWordWithNestedExampleSuggestionData)
       .then((genericWordRes) => {
         expect(genericWordRes.status).to.equal(200);
-        createWord(genericWordRes.body)
+        createWord(genericWordRes.body.id)
           .then((mergedWordRes) => {
             expect(mergedWordRes.status).to.equal(200);
             setTimeout(() => {
@@ -253,7 +252,7 @@ describe('Editing Flow', () => {
         updateGenericWord(genericWord.id, genericWord)
           .then((updatedGenericWordRes) => {
             expect(updatedGenericWordRes.status).to.equal(200);
-            createWord({ id: genericWord.id, docType: SuggestionTypes.GENERIC_WORDS })
+            createWord(genericWord.id)
               .then((firstWordRes) => {
                 expect(firstWordRes.status).to.equal(200);
                 setTimeout(() => {
@@ -270,7 +269,7 @@ describe('Editing Flow', () => {
                         .then((secondGenericWordRes) => {
                           expect(secondGenericWordRes.status).to.equal(200);
                           setTimeout(() => {
-                            createWord({ id: secondGenericWordRes.body.id })
+                            createWord(secondGenericWordRes.body.id)
                               .then((secondWordRes) => {
                                 expect(secondWordRes.status).to.equal(200);
                                 getExample(secondWordRes.body.examples[0].id)

--- a/tests/exampleSuggestions.test.js
+++ b/tests/exampleSuggestions.test.js
@@ -29,7 +29,7 @@ describe('MongoDB Example Suggestions', () => {
   before((done) => {
     suggestNewWord(wordSuggestionData)
       .then((res) => {
-        createWord(res.body)
+        createWord(res.body.id)
           .then(() => done());
       });
   });

--- a/tests/examples.test.js
+++ b/tests/examples.test.js
@@ -31,7 +31,7 @@ describe('MongoDB Examples', () => {
         .then((res) => {
           expect(res.status).to.equal(200);
           const mergingExampleSuggestion = { ...res.body, ...exampleSuggestionData };
-          createExample(mergingExampleSuggestion)
+          createExample(mergingExampleSuggestion.id)
             .then((result) => {
               expect(result.status).to.equal(200);
               expect(result.body.id).to.not.equal(undefined);
@@ -59,7 +59,7 @@ describe('MongoDB Examples', () => {
             .then((examplesRes) => {
               const firstExample = examplesRes.body[0];
               const mergingExampleSuggestion = { ...res.body, originalExampleId: firstExample.id };
-              createExample(mergingExampleSuggestion)
+              createExample(mergingExampleSuggestion.id)
                 .then((result) => {
                   expect(result.status).to.equal(200);
                   expect(result.body.id).to.not.equal(undefined);
@@ -84,7 +84,7 @@ describe('MongoDB Examples', () => {
       suggestNewExample(exampleSuggestionData)
         .then((res) => {
           const malformedMergingExampleSuggestion = { ...res.body, ...malformedExampleSuggestionData };
-          createExample(malformedMergingExampleSuggestion)
+          createExample(malformedMergingExampleSuggestion.id)
             .end((_, result) => {
               expect(result.status).to.equal(200);
               expect(result.body.error).to.equal(undefined);
@@ -97,7 +97,7 @@ describe('MongoDB Examples', () => {
       suggestNewExample(exampleSuggestionData)
         .then((res) => {
           const mergingExampleSuggestion = { ...res.body, ...exampleSuggestionData };
-          createExample(mergingExampleSuggestion)
+          createExample(mergingExampleSuggestion.id)
             .then((result) => {
               expect(result.status).to.equal(200);
               expect(result.body.id).to.not.equal(undefined);
@@ -115,7 +115,7 @@ describe('MongoDB Examples', () => {
       suggestNewExample(exampleSuggestionData)
         .then((res) => {
           const mergingExampleSuggestion = { ...res.body, ...exampleSuggestionData };
-          createExample(mergingExampleSuggestion)
+          createExample(mergingExampleSuggestion.id)
             .then((result) => {
               expect(result.status).to.equal(200);
               expect(result.body.id).to.not.equal(undefined);
@@ -135,7 +135,7 @@ describe('MongoDB Examples', () => {
       suggestNewExample(exampleSuggestionData)
         .then((res) => {
           const mergingExampleSuggestion = { ...res.body, ...exampleSuggestionData };
-          createExample(mergingExampleSuggestion)
+          createExample(mergingExampleSuggestion.id)
             .then((result) => {
               expect(result.status).to.equal(200);
               expect(result.body.id).to.not.equal(undefined);

--- a/tests/shared/commands.js
+++ b/tests/shared/commands.js
@@ -2,7 +2,6 @@ import chai from 'chai';
 import server from '../../src/server';
 import { API_ROUTE, TEST_ROUTE, API_URL } from './constants';
 import createRegExp from '../../src/shared/utils/createRegExp';
-import SuggestionTypes from '../../src/shared/constants/suggestionTypes';
 import { resultsFromDictionarySearch } from '../../src/services/words';
 import { sendEmail } from '../../src/controllers/mail';
 import mockedData from '../__mocks__/data.mock.json';
@@ -64,21 +63,20 @@ export const deleteGenericWord = (id) => (
     .delete(`${API_ROUTE}/genericWords/${id}`)
 );
 
-// TODO: #240 only take in ids
-export const createWord = (data, query = {}) => (
+export const createWord = (id, query = {}) => (
   chai
     .request(server)
     .post(`${API_ROUTE}/words`)
     .query(query)
-    .send({ docType: SuggestionTypes.WORD_SUGGESTIONS, ...data })
+    .send({ id })
 );
 
-export const createExample = (data, query = {}) => (
+export const createExample = (id, query = {}) => (
   chai
     .request(server)
     .post(`${API_ROUTE}/examples`)
     .query(query)
-    .send(data)
+    .send({ id })
 );
 
 export const suggestNewWord = (data) => (


### PR DESCRIPTION
This PR:
* Removes the concept of `SuggestionTypes.WORD_SUGGESTIONS` and `SuggestionTypes.GENERIC_WORDS`
* Updates the test suite to only expect a `wordSuggestion`, `genericWord`, or `exampleSuggestion` id passed in as the firsrt argument of `createWord` or `createExample`

Closes #244 
Closes #240 