### PR TITLE
 Return createGenericWords promises

### DIFF
--- a/src/controllers/genericWords.js
+++ b/src/controllers/genericWords.js
@@ -125,17 +125,20 @@ export const getGenericWord = (req, res) => {
     });
 };
 
-/* Populates the MongoDB database with GenericWords */
-export const createGenericWords = (_, res) => {
-  const dictionary = process.env.NODE_ENV === 'test' ? testGenericWordsDictionary : genericWordsDictionary;
-  const genericWordsPromises = map(dictionary, (value, key) => {
+const seedGenericWords = async (dictionary) => (
+  map(dictionary, (value, key) => {
     const newGenericWord = new GenericWord({
       word: key,
       definitions: value,
     });
     return newGenericWord.save();
-  });
+  })
+);
 
+/* Populates the MongoDB database with GenericWords */
+export const createGenericWords = async (_, res) => {
+  const dictionary = process.env.NODE_ENV === 'test' ? testGenericWordsDictionary : genericWordsDictionary;
+  const genericWordsPromises = await seedGenericWords(dictionary);
   return Promise.all(genericWordsPromises)
     .then(() => (
       res.send({ message: 'Successfully populated generic words' })

--- a/src/controllers/genericWords.js
+++ b/src/controllers/genericWords.js
@@ -136,7 +136,7 @@ export const createGenericWords = (_, res) => {
     return newGenericWord.save();
   });
 
-  Promise.all(genericWordsPromises)
+  return Promise.all(genericWordsPromises)
     .then(() => (
       res.send({ message: 'Successfully populated generic words' })
     ))


### PR DESCRIPTION
Whenever a user makes a 'POST' network request to `api/v1/genericWords` to seed the database with some genericWords, an `ERR_EMPTY_RESPONSE` response header would be returned. This would break out testing environments.