### PR TITLE
Assign mergedBy field for nested examples

### DIFF
--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -154,7 +154,7 @@ const updateSuggestionAfterMerge = async (suggestionDoc, originalWordDoc, merged
       removeSuggestionAssociatedIds.associatedWords.push(originalWordDoc.id);
     }
     const updatedExampleSuggestion = await removeSuggestionAssociatedIds.save();
-    return executeMergeExample(updatedExampleSuggestion.id);
+    return executeMergeExample(updatedExampleSuggestion.id, mergedBy);
   }));
   return updatedSuggestionDoc.save();
 };

--- a/tests/api-mongo.test.js
+++ b/tests/api-mongo.test.js
@@ -694,3 +694,5 @@ describe('MongoDB Words', () => {
     });
   });
 });
+
+// TODO: write test to check if mergedBy field for nested examples gets populated


### PR DESCRIPTION
The `mergedBy` field in nested exampleSuggestions is null once actually merged. This is a bug since the `uid` of the user that merged the exampleSuggestion should be listed there.

This PR fixes this bug.