### PR TITLE
Hide recipient list for all emails and change automated email times

### DIFF
--- a/src/controllers/email.js
+++ b/src/controllers/email.js
@@ -1,4 +1,4 @@
-import { omit } from 'lodash';
+import { map, omit } from 'lodash';
 import {
   MERGED_SUGGESTION_TEMPLATE,
   REJECTED_SUGGESTION_TEMPLATE,
@@ -10,8 +10,10 @@ const sgMail = process.env.NODE_ENV !== 'build' ? require('@sendgrid/mail') : {}
 
 /* Builds the message object that will help send the email */
 const constructMessage = (messageFields) => ({
-  from: FROM_EMAIL,
   ...messageFields,
+  from: { email: FROM_EMAIL, name: 'Igbo API' },
+  reply_to: { email: FROM_EMAIL, name: 'Igbo API' },
+  personalizations: map(messageFields.to, (to) => ({ to: [{ email: to }] })),
 });
 
 /* Wrapper around SendGrid function to handle errors */

--- a/src/services/sendEmail.js
+++ b/src/services/sendEmail.js
@@ -69,8 +69,8 @@ const sendEmailJob = async () => {
 };
 
 if (process.env.NODE_ENV === 'production') {
-  /* Runs every Monday at 9AM */
-  cron.schedule('0 9 * * 1', sendEmailJob);
+  /* Runs every Monday at 6AM PST */
+  cron.schedule('0 14 * * 1', sendEmailJob);
 }
 
 export default sendEmailJob;


### PR DESCRIPTION
* Changes the automated message time from Mondays at 1AM PST to Mondays at 6AM PST
* The `from` field is updated to now include an object that includes the `from` email and name
* Uses `personalizations` field to simulate blind carbon copied (BCC) emails