### PR TITLE
Sort documents

### DIFF
--- a/src/controllers/exampleSuggestions.js
+++ b/src/controllers/exampleSuggestions.js
@@ -4,6 +4,7 @@ import {
   some,
   map,
   uniq,
+  orderBy,
 } from 'lodash';
 import SuggestionTypes from '../shared/constants/suggestionTypes';
 import SortingDirections from '../shared/constants/sortingDirections';
@@ -118,13 +119,13 @@ export const findExampleSuggestionById = (id) => (
   ExampleSuggestion.findById(id)
 );
 
-const findExampleSuggestions = ({ regexMatch, skip, limit }) => (
-  ExampleSuggestion
-    .find(regexMatch)
-    .sort({ approvals: SortingDirections.DESCENDING })
-    .skip(skip)
-    .limit(limit)
-);
+/* Grabs ExampleSugestions and sorts them by number of approvals in descending order */
+const findExampleSuggestions = async ({ regexMatch, skip, limit }) => {
+  const exampleSuggestions = await ExampleSuggestion
+    .find(regexMatch);
+  const sortedExampleSuggestions = orderBy(exampleSuggestions, ['approvals'], SortingDirections.DESCENDING);
+  return sortedExampleSuggestions.slice(skip, skip + limit);
+};
 
 /* Returns all existing ExampleSuggestion objects */
 export const getExampleSuggestions = (req, res) => {

--- a/src/controllers/genericWords.js
+++ b/src/controllers/genericWords.js
@@ -5,6 +5,7 @@ import {
   partial,
   map,
   trim,
+  orderBy,
 } from 'lodash';
 import GenericWord from '../models/GenericWord';
 import testGenericWordsDictionary from '../../tests/__mocks__/genericWords.mock.json';
@@ -61,13 +62,13 @@ export const findGenericWordById = (id) => (
   GenericWord.findById(id)
 );
 
-export const findGenericWords = ({ regexMatch, skip, limit }) => (
-  GenericWord
-    .find(regexMatch)
-    .sort({ approvals: SortingDirections.DESCENDING })
-    .skip(skip)
-    .limit(limit)
-);
+/* Grabs GenericWords and sorts them by number of approvals in descending order */
+export const findGenericWords = async ({ regexMatch, skip, limit }) => {
+  const genericWords = await GenericWord
+    .find(regexMatch);
+  const sortedGenericWords = orderBy(genericWords, ['approvals'], [SortingDirections.DESCENDING]);
+  return sortedGenericWords.slice(skip, skip + limit);
+};
 
 /* Returns all existing GenericWord objects */
 export const getGenericWords = (req, res) => {

--- a/src/controllers/wordSuggestions.js
+++ b/src/controllers/wordSuggestions.js
@@ -6,6 +6,7 @@ import {
   partial,
   map,
   trim,
+  orderBy,
 } from 'lodash';
 import WordSuggestion from '../models/WordSuggestion';
 import { packageResponse, handleQueries, populateFirebaseUsers } from './utils';
@@ -59,13 +60,13 @@ export const findWordSuggestionById = (id) => (
   WordSuggestion.findById(id)
 );
 
-const findWordSuggestions = ({ regexMatch, skip, limit }) => (
-  WordSuggestion
-    .find(regexMatch)
-    .sort({ approvals: SortingDirections.DESCENDING })
-    .skip(skip)
-    .limit(limit)
-);
+/* Grabs WordSuggestions and sorts them by number of approvals in descending order */
+const findWordSuggestions = async ({ regexMatch, skip, limit }) => {
+  const wordSuggestions = await WordSuggestion
+    .find(regexMatch);
+  const sortedWordSuggestions = orderBy(wordSuggestions, ['approvals'], [SortingDirections.DESCENDING]);
+  return sortedWordSuggestions.slice(skip, skip + limit);
+};
 
 /* Updates an existing WordSuggestion object */
 // TODO: #272 handle this elsewhere

--- a/src/middleware/authentication.js
+++ b/src/middleware/authentication.js
@@ -35,7 +35,9 @@ const authentication = async (req, res, next) => {
           req.user = { role: decoded.role, uid: decoded.uid };
         }
       } catch {
-        console.warn('Error while authing Firebase token');
+        if (process.env.NODE_ENV === 'production') {
+          throw new Error('Error while authing Firebase token');
+        }
       }
       return next();
     }

--- a/tests/__mocks__/documentData.js
+++ b/tests/__mocks__/documentData.js
@@ -81,13 +81,6 @@ const genericWordData = {
   definitions: ['definition'],
 };
 
-const genericWordApprovedData = {
-  word: 'genericWord',
-  wordClass: 'noun',
-  definitions: [],
-  approvals: ['first user', 'second user'],
-};
-
 const malformedGenericWordData = {
   word: 'newGenericWord',
   wordClass: '',
@@ -130,7 +123,6 @@ export {
   exampleData,
   updatedExampleData,
   genericWordData,
-  genericWordApprovedData,
   malformedGenericWordData,
   updatedGenericWordData,
 };

--- a/tests/api-mongo.test.js
+++ b/tests/api-mongo.test.js
@@ -119,7 +119,7 @@ describe('MongoDB Words', () => {
           expect(res.status).to.equal(200);
           const firstGenericWord = res.body[0];
           firstGenericWord.wordClass = 'something new';
-          updateGenericWord(firstGenericWord.id, firstGenericWord)
+          updateGenericWord(firstGenericWord)
             .then((saveMergedGenericWord) => {
               expect(saveMergedGenericWord.status).to.equal(200);
               createWord(firstGenericWord.id)
@@ -191,7 +191,7 @@ describe('MongoDB Words', () => {
           expect(res.status).to.equal(200);
           const firstWordSuggestion = res.body[0];
           firstWordSuggestion.wordClass = 'wordClass';
-          updateWordSuggestion(firstWordSuggestion.id, firstWordSuggestion)
+          updateWordSuggestion(firstWordSuggestion)
             .then((updatedWordSuggestionRes) => {
               expect(updatedWordSuggestionRes.status).to.equal(200);
               createWord(updatedWordSuggestionRes.body.id)
@@ -217,7 +217,7 @@ describe('MongoDB Words', () => {
           expect(res.status).to.equal(200);
           const firstGenericWord = res.body[0];
           firstGenericWord.wordClass = 'wordClass';
-          updateGenericWord(firstGenericWord.id, firstGenericWord)
+          updateGenericWord(firstGenericWord)
             .then((updatedGenericWordRes) => {
               expect(updatedGenericWordRes.status).to.equal(200);
               createWord(updatedGenericWordRes.body.id)
@@ -310,7 +310,7 @@ describe('MongoDB Words', () => {
             .then((result) => {
               expect(result.status).to.equal(200);
               expect(result.body.id).to.not.equal(undefined);
-              updateWord(result.body.id, updatedWordData)
+              updateWord({ id: result.body.id, ...updatedWordData })
                 .end((_, updateWordRes) => {
                   expect(updateWordRes.status).to.equal(200);
                   forIn(updatedWordData, (value, key) => {

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -115,7 +115,7 @@ describe('Auth', () => {
         });
     });
 
-    it.skip('should allow an admin to get all users', (done) => {
+    it('should allow an admin to get all users', (done) => {
       getUsers()
         .end((_, res) => {
           expect(res.status).to.equal(200);
@@ -123,7 +123,7 @@ describe('Auth', () => {
         });
     });
 
-    it.skip('should forbid a non-admin from getting users', (done) => {
+    it('should forbid a non-admin from getting users', (done) => {
       getUsers({ role: 'merger' })
         .end((_, res) => {
           expect(res.status).to.equal(403);

--- a/tests/editing-flow.test.js
+++ b/tests/editing-flow.test.js
@@ -232,7 +232,7 @@ describe('Editing Flow', () => {
           ...wordSuggestionRes.body,
           word: 'newWord',
         };
-        updateWordSuggestion(updatedWordSuggestion.id, updatedWordSuggestion)
+        updateWordSuggestion(updatedWordSuggestion)
           .end((_, res) => {
             expect(res.status).to.equal(200);
             expect(res.body.word).to.equal('newWord');
@@ -254,7 +254,7 @@ describe('Editing Flow', () => {
           english,
           associatedWords: [genericWordsRes.body[0].id],
         }];
-        updateGenericWord(genericWord.id, genericWord)
+        updateGenericWord(genericWord)
           .then((updatedGenericWordRes) => {
             expect(updatedGenericWordRes.status).to.equal(200);
             createWord(genericWord.id)
@@ -298,7 +298,7 @@ describe('Editing Flow', () => {
     getGenericWords({ keyword: 'meru' })
       .then((genericWordsRes) => {
         expect(genericWordsRes.status).to.equal(200);
-        updateGenericWord(genericWordsRes.body[0].id, genericWordWithNestedExampleSuggestionData)
+        updateGenericWord({ id: genericWordsRes.body[0].id, ...genericWordWithNestedExampleSuggestionData })
           .then((genericWordRes) => {
             expect(genericWordRes.status).to.equal(200);
             const nestedExampleSuggestion = genericWordRes.body.examples[0];

--- a/tests/examples.test.js
+++ b/tests/examples.test.js
@@ -175,7 +175,7 @@ describe('MongoDB Examples', () => {
             .then((result) => {
               expect(result.status).to.equal(200);
               expect(result.body.id).to.not.equal(undefined);
-              updateExample(result.body.id, updatedExampleData)
+              updateExample({ id: result.body.id, ...updatedExampleData })
                 .end((_, exampleRes) => {
                   expect(exampleRes.status).to.equal(200);
                   expect(new Date(result.body.updatedOn))

--- a/tests/genericWords.test.js
+++ b/tests/genericWords.test.js
@@ -2,6 +2,7 @@ import chai from 'chai';
 import { forIn, forEach, isEqual } from 'lodash';
 import SortingDirections from '../src/shared/constants/sortingDirections';
 import {
+  approveGenericWord,
   getGenericWords,
   getGenericWord,
   updateGenericWord,
@@ -13,7 +14,7 @@ import {
   NONEXISTENT_ID,
 } from './shared/constants';
 import { expectUniqSetsOfResponses, expectArrayIsInOrder } from './shared/utils';
-import { genericWordApprovedData, malformedGenericWordData, updatedGenericWordData } from './__mocks__/documentData';
+import { malformedGenericWordData, updatedGenericWordData } from './__mocks__/documentData';
 
 const { expect } = chai;
 
@@ -23,7 +24,7 @@ describe('MongoDB Generic Words', () => {
       getGenericWords()
         .then((res) => {
           expect(res.status).to.equal(200);
-          updateGenericWord(res.body[0].id, updatedGenericWordData)
+          updateGenericWord({ id: res.body[0].id, ...updatedGenericWordData })
             .end((_, result) => {
               expect(result.status).to.equal(200);
               forIn(updatedGenericWordData, (value, key) => {
@@ -38,7 +39,7 @@ describe('MongoDB Generic Words', () => {
       getGenericWords()
         .then((res) => {
           expect(res.status).to.equal(200);
-          updateGenericWord(res.body[0].id, malformedGenericWordData)
+          updateGenericWord({ id: res.body[0].id, ...malformedGenericWordData })
             .end((_, result) => {
               expect(result.status).to.equal(400);
               done();
@@ -56,7 +57,7 @@ describe('MongoDB Generic Words', () => {
     });
 
     it('should throw an error for providing an invalid id', (done) => {
-      updateGenericWord(INVALID_ID)
+      updateGenericWord({ id: INVALID_ID })
         .end((_, res) => {
           expect(res.status).to.equal(400);
           expect(res.body.error).to.not.equal(undefined);
@@ -69,7 +70,7 @@ describe('MongoDB Generic Words', () => {
         .then((genericWordsRes) => {
           expect(genericWordsRes.status).to.equal(200);
           const genericWord = genericWordsRes.body[0];
-          updateGenericWord(genericWord.id, { ...genericWord, word: 'updated' })
+          updateGenericWord({ ...genericWord, word: 'updated' })
             .end((_, res) => {
               expect(res.status).to.equal(200);
               expect(Date.parse(genericWord.updatedOn)).to.be.lessThan(Date.parse(res.body.updatedOn));
@@ -120,7 +121,7 @@ describe('MongoDB Generic Words', () => {
       getGenericWords()
         .then((res) => {
           expect(res.status).to.equal(200);
-          updateGenericWord(res.body[0].id, genericWordApprovedData)
+          approveGenericWord(res.body[0])
             .then(() => {
               getGenericWords()
                 .end((_, result) => {

--- a/tests/shared/commands.js
+++ b/tests/shared/commands.js
@@ -99,40 +99,58 @@ export const suggestNewExample = (data) => (
     .send(data)
 );
 
-export const updateWordSuggestion = (id, data) => (
+export const updateWordSuggestion = (data) => (
   chai
     .request(server)
-    .put(`${API_ROUTE}/wordSuggestions/${id}`)
+    .put(`${API_ROUTE}/wordSuggestions/${data.id}`)
     .send(data)
 );
 
-export const updateExampleSuggestion = (id, data) => (
+export const updateExampleSuggestion = (data) => (
   chai
     .request(server)
-    .put(`${API_ROUTE}/exampleSuggestions/${id}`)
+    .put(`${API_ROUTE}/exampleSuggestions/${data.id}`)
     .send(data)
 );
 
-export const updateGenericWord = (id, data) => (
+export const updateGenericWord = (data) => (
   chai
     .request(server)
-    .put(`${API_ROUTE}/genericWords/${id}`)
+    .put(`${API_ROUTE}/genericWords/${data.id}`)
     .send(data)
 );
 
-export const updateWord = (id, data) => (
+export const updateWord = (data) => (
   chai
     .request(server)
-    .put(`${API_ROUTE}/words/${id}`)
+    .put(`${API_ROUTE}/words/${data.id}`)
     .send(data)
 );
 
-export const updateExample = (id, data) => (
+export const updateExample = (data) => (
   chai
     .request(server)
-    .put(`${API_ROUTE}/examples/${id}`)
+    .put(`${API_ROUTE}/examples/${data.id}`)
     .send(data)
 );
+
+export const approveWordSuggestion = (data) => {
+  const approvedData = data;
+  approvedData.approvals.push('approval');
+  return updateWordSuggestion(data.id, data);
+};
+
+export const approveExampleSuggestion = (data) => {
+  const approvedData = data;
+  approvedData.approvals.push('approval');
+  return updateExampleSuggestion(data.id, data);
+};
+
+export const approveGenericWord = (data) => {
+  const approvedData = data;
+  approvedData.approvals.push('approval');
+  return updateGenericWord(data.id, data);
+};
 
 /* Searches for words using the data in MongoDB */
 export const getWords = (query = {}) => (


### PR DESCRIPTION
The API will now return a sorted list of wordSuggestions, exampleSuggestions, and wordSuggestions by number approvals in descending order

This PR also:
* Updates the API of test commands to reduce repeated logic
* Removes `skip` suffix for two tests
* Closes #266 