### PR TITLE
Change sorting logic to rely on updated on and approvals

### DIFF
--- a/src/controllers/exampleSuggestions.js
+++ b/src/controllers/exampleSuggestions.js
@@ -118,11 +118,11 @@ export const findExampleSuggestionById = (id) => (
   ExampleSuggestion.findById(id)
 );
 
-/* Grabs ExampleSugestions and sorts them by number of approvals in descending order */
+/* Grabs ExampleSugestions and sorts them by their last update in descending order */
 const findExampleSuggestions = ({ regexMatch, skip, limit }) => (
   ExampleSuggestion
     .find(regexMatch)
-    .sort({ approvals: SortingDirections.DESCENDING })
+    .sort({ updatedOn: SortingDirections.DESCENDING })
     .skip(skip)
     .limit(limit)
 );

--- a/src/controllers/genericWords.js
+++ b/src/controllers/genericWords.js
@@ -61,11 +61,11 @@ export const findGenericWordById = (id) => (
   GenericWord.findById(id)
 );
 
-/* Grabs GenericWords and sorts them by number of approvals in descending order */
+/* Grabs GenericWords and sorts them by their last update in descending order */
 export const findGenericWords = async ({ regexMatch, skip, limit }) => (
   GenericWord
     .find(regexMatch)
-    .sort({ approvals: SortingDirections.DESCENDING })
+    .sort({ updatedOn: SortingDirections.DESCENDING })
     .skip(skip)
     .limit(limit)
 );

--- a/src/controllers/utils/index.js
+++ b/src/controllers/utils/index.js
@@ -143,7 +143,8 @@ const parseSortKeys = (sort) => {
   try {
     if (sort) {
       const parsedSort = JSON.parse(sort);
-      const [key] = parsedSort;
+      const [key] = parsedSort[0] === 'approvals' || parsedSort[0] === 'denials'
+        ? [`${parsedSort[0]}.length`] : parsedSort;
       const direction = parsedSort[1].toLowerCase();
       if (direction.toLowerCase() !== SortingDirections.ASCENDING
         && direction.toLowerCase() !== SortingDirections.DESCENDING) {

--- a/src/controllers/wordSuggestions.js
+++ b/src/controllers/wordSuggestions.js
@@ -59,11 +59,11 @@ export const findWordSuggestionById = (id) => (
   WordSuggestion.findById(id)
 );
 
-/* Grabs WordSuggestions and sorts them by number of approvals in descending order */
+/* Grabs WordSuggestions and sorts them by their last update in descending order */
 const findWordSuggestions = async ({ regexMatch, skip, limit }) => (
   WordSuggestion
     .find(regexMatch)
-    .sort({ approvals: SortingDirections.DESCENDING })
+    .sort({ updatedOn: SortingDirections.DESCENDING })
     .skip(skip)
     .limit(limit)
 );


### PR DESCRIPTION
Sorting Suggestion type documents will now rely on the `updatedOn` and the `approvals` keys.