### PR TITLE
Change word example schemas

### DIFF
--- a/migrations/20201206042142-add-accented-field.js
+++ b/migrations/20201206042142-add-accented-field.js
@@ -1,0 +1,23 @@
+module.exports = {
+  async up(db) {
+    return [
+      db.collection('words').updateMany({}, [{
+        $set: { accented: '$word' },
+      }]),
+      db.collection('examples').updateMany({}, [{
+        $set: { accented: '$igbo' },
+      }]),
+    ];
+  },
+
+  async down(db) {
+    return [
+      db.collection('words').updateMany({}, {
+        $unset: { accented: null },
+      }),
+      db.collection('examples').updateMany({}, {
+        $unset: { accented: null },
+      }),
+    ];
+  },
+};

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "react-dom": "^17.0.0",
     "react-json-pretty": "^2.2.0",
     "react-scroll": "^1.8.1",
+    "remove-accents": "^0.4.2",
     "rimraf": "^3.0.2",
     "shelljs": "^0.8.4",
     "string-similarity": "^4.0.2",

--- a/src/controllers/utils/buildDocs.js
+++ b/src/controllers/utils/buildDocs.js
@@ -2,13 +2,23 @@
 /* eslint-disable no-underscore-dangle */
 
 import { assign, map, forEach } from 'lodash';
+import accents from 'remove-accents';
 import Word from '../../models/Word';
 
-/* Removes _id and __v from nested documents */
+/**
+ * Removes _id and __v from nested documents
+ * Normalizes (removes accent marks) from word and example's igbo
+ */
 const removeKeysInNestedDoc = (docs, nestedDocsKey) => {
   forEach(docs, (doc) => {
+    // Handles removing accent marks for word
+    doc.word = accents.remove(doc.word);
     doc[nestedDocsKey] = map(doc[nestedDocsKey], (nestedDoc) => {
       const updatedNestedDoc = assign(nestedDoc, { id: nestedDoc._id });
+      if (nestedDocsKey === 'examples') {
+        // Handles remove accent marks for example's igbo
+        updatedNestedDoc.igbo = accents.remove(updatedNestedDoc.igbo);
+      }
       delete updatedNestedDoc._id;
       delete updatedNestedDoc.__v;
       return updatedNestedDoc;
@@ -42,6 +52,7 @@ export const findWordsWithMatch = async ({ match, skip = 0, limit = 10 }) => {
       normalized: 1,
       examples: 1,
       updatedOn: 1,
+      accented: 1,
     });
 
   return removeKeysInNestedDoc(words, 'examples');

--- a/src/models/Example.js
+++ b/src/models/Example.js
@@ -1,15 +1,22 @@
 import mongoose from 'mongoose';
-import { toJSONPlugin, toObjectPlugin, updatedOnHook } from './plugins';
+import {
+  toJSONPlugin,
+  toObjectPlugin,
+  updatedOnHook,
+  normalizeExampleHook,
+} from './plugins';
 
 const { Schema, Types } = mongoose;
 const exampleSchema = new Schema({
   igbo: { type: String, default: '' },
   english: { type: String, default: '' },
   associatedWords: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
+  accented: { type: String, default: '' },
   updatedOn: { type: Date, default: Date.now() },
 }, { toObject: toObjectPlugin });
 
 toJSONPlugin(exampleSchema);
 updatedOnHook(exampleSchema);
+normalizeExampleHook(exampleSchema);
 
 export default mongoose.model('Example', exampleSchema);

--- a/src/models/Word.js
+++ b/src/models/Word.js
@@ -1,5 +1,10 @@
 import mongoose from 'mongoose';
-import { toJSONPlugin, toObjectPlugin, updatedOnHook } from './plugins';
+import {
+  normalizeWordHook,
+  toJSONPlugin,
+  toObjectPlugin,
+  updatedOnHook,
+} from './plugins';
 
 const { Schema } = mongoose;
 const wordSchema = new Schema({
@@ -10,10 +15,12 @@ const wordSchema = new Schema({
   normalized: { type: String, default: '' },
   frequency: { type: Number },
   stems: { type: [{ type: String }], default: [] },
+  accented: { type: String, default: '' },
   updatedOn: { type: Date, default: Date.now() },
 }, { toObject: toObjectPlugin });
 
 toJSONPlugin(wordSchema);
 updatedOnHook(wordSchema);
+normalizeWordHook(wordSchema);
 
 export default mongoose.model('Word', wordSchema);

--- a/src/models/plugins/index.js
+++ b/src/models/plugins/index.js
@@ -2,7 +2,9 @@
 /* Code from https://stackoverflow.com/q/30431262 */
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable no-param-reassign */
+import { map } from 'lodash';
 import mongoose from 'mongoose';
+import accents from 'remove-accents';
 
 /* Replaces the _id key with id */
 export const toJSONPlugin = (schema) => {
@@ -34,3 +36,31 @@ export const updatedOnHook = (schema) => (
     return this;
   })
 );
+
+/* Removes accent marks found in the word field before sending to client */
+export const normalizeWordHook = (schema) => {
+  schema.post('find', (docs) => (
+    map(docs, (doc) => {
+      doc.word = accents.remove(doc.word);
+      return doc;
+    })
+  ));
+  schema.post('findOne', (doc) => {
+    doc.word = accents.remove(doc.word);
+    return doc;
+  });
+};
+
+/* Removes accent marks found in the igbo text before sending to client */
+export const normalizeExampleHook = (schema) => {
+  schema.post('find', (docs) => (
+    map(docs, (doc) => {
+      doc.igbo = accents.remove(doc.igbo);
+      return doc;
+    })
+  ));
+  schema.post('findOne', (doc) => {
+    doc.igbo = accents.remove(doc.igbo);
+    return doc;
+  });
+};

--- a/tests/api-mongo.test.js
+++ b/tests/api-mongo.test.js
@@ -10,6 +10,7 @@ import {
 } from 'lodash';
 import stringSimilarity from 'string-similarity';
 import diacriticless from 'diacriticless';
+import accents from 'remove-accents';
 import Word from '../src/models/Word';
 import {
   WORD_KEYS,
@@ -574,7 +575,7 @@ describe('MongoDB Words', () => {
         expect(res.status).to.equal(200);
         expect(res.body).to.be.an('array');
         expect(res.body).to.have.lengthOf(1);
-        expect(res.body[0].word).to.equal('-mụ-mù');
+        expect(res.body[0].word).to.equal(accents.remove('-mụ-mù'));
         expect(some(res.body, (word) => isEqual(word.variations, ['-mu-mù']))).to.equal(true);
         done();
       });
@@ -689,6 +690,18 @@ describe('MongoDB Words', () => {
         .end((_, res) => {
           expect(res.status).to.equal(200);
           expect(res.body).to.have.lengthOf(0);
+          done();
+        });
+    });
+
+    it('should return accented field and normalized word', (done) => {
+      getWords()
+        .end((_, res) => {
+          expect(res.status).to.equal(200);
+          forEach(res.body, (word) => {
+            expect(word.word).to.equal(accents.remove(word.word));
+            expect(word.accented).to.not.equal(undefined);
+          });
           done();
         });
     });

--- a/tests/examples.test.js
+++ b/tests/examples.test.js
@@ -1,5 +1,11 @@
 import chai from 'chai';
-import { isEqual, forIn, some } from 'lodash';
+import {
+  isEqual,
+  forIn,
+  some,
+  forEach,
+} from 'lodash';
+import accents from 'remove-accents';
 import SortingDirections from '../src/shared/constants/sortingDirections';
 import {
   createExample,
@@ -332,6 +338,31 @@ describe('MongoDB Examples', () => {
         .end((_, res) => {
           expect(res.status).to.equal(200);
           expect(res.body).to.have.lengthOf(0);
+          done();
+        });
+    });
+
+    it('should return accented field with keyword', (done) => {
+      const keyword = 'Òbìàgèlì bì n’Àba';
+      getExamples({ keyword })
+        .end((_, res) => {
+          expect(res.status).to.equal(200);
+          forEach(res.body, (example) => {
+            expect(example.igbo).to.equal(accents.remove(keyword));
+            expect(example.igbo).to.not.equal(undefined);
+          });
+          done();
+        });
+    });
+
+    it('should return accented field and normalized example', (done) => {
+      getExamples()
+        .end((_, res) => {
+          expect(res.status).to.equal(200);
+          forEach(res.body, (example) => {
+            expect(example.igbo).to.equal(accents.remove(example.igbo));
+            expect(example.igbo).to.not.equal(undefined);
+          });
           done();
         });
     });

--- a/tests/shared/constants.js
+++ b/tests/shared/constants.js
@@ -8,6 +8,7 @@ export const API_URL = 'https://igboapi.com';
 export const SAVE_DOC_DELAY = 2000;
 
 export const WORD_KEYS = [
+  'accented',
   'variations',
   'definitions',
   'stems',
@@ -18,7 +19,7 @@ export const WORD_KEYS = [
   'wordClass',
   'updatedOn',
 ];
-export const EXAMPLE_KEYS = ['igbo', 'english', 'associatedWords', 'id', 'updatedOn'];
+export const EXAMPLE_KEYS = ['accented', 'igbo', 'english', 'associatedWords', 'id', 'updatedOn'];
 export const EXAMPLE_SUGGESTION_KEYS = [
   'originalExampleId',
   'igbo',

--- a/yarn.lock
+++ b/yarn.lock
@@ -9021,6 +9021,11 @@ regjsparser@^0.6.4:
   dependencies:
     jsesc "~0.5.0"
 
+remove-accents@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"


### PR DESCRIPTION
The Igbo language doesn't include accent marks in everyday writing. However, the accent marks are helpful for denoted tone. There's now a new `accented` field that lives on words and examples that will include tone markings.

The database migration couldn't accept custom functions and references to documents, so it was impossible to remove the accent marks for every document in the database migration up function. To get around this problem, there are `find` and `findOne` hooks for words and examples that will remove the accent marks from the `word` and `igbo` fields before it gets sent back to the client.

This means, in the database, the `word` and `igbo` fields still have accent marks, but they get processed before they reach the client.