### PR TITLE
Strict search

### DIFF
--- a/src/controllers/utils/index.js
+++ b/src/controllers/utils/index.js
@@ -169,6 +169,7 @@ export const handleQueries = ({ query = {}, user = {} }) => {
     range: rangeQuery = '',
     sort: sortQuery,
     filter: filterQuery,
+    strict: strictQuery,
   } = query;
   const filter = convertFilterToKeyword(filterQuery);
   const searchWord = removePrefix(keyword || filter || '');
@@ -177,6 +178,7 @@ export const handleQueries = ({ query = {}, user = {} }) => {
   const range = parseRange(rangeQuery);
   const { skip, limit } = convertToSkipAndLimit({ page, range });
   const sort = parseSortKeys(sortQuery);
+  const strict = strictQuery === 'true';
   return {
     searchWord,
     regexKeyword,
@@ -184,6 +186,7 @@ export const handleQueries = ({ query = {}, user = {} }) => {
     sort,
     skip,
     limit,
+    strict,
   };
 };
 

--- a/src/controllers/utils/queries.js
+++ b/src/controllers/utils/queries.js
@@ -1,4 +1,5 @@
 import { LOOK_BACK_DATE } from '../../shared/constants/emailDates';
+import createRegExp from '../../shared/utils/createRegExp';
 
 const wordQuery = (regex) => ({ word: { $regex: regex } });
 const variationsQuery = (regex) => ({ variations: { $in: [regex] } });
@@ -28,6 +29,11 @@ export const searchPreExistingGenericWordsRegexQuery = (regex) => ({
 });
 export const searchIgboRegexQuery = (regex) => ({
   $or: [wordQuery(regex), variationsQuery(regex)],
+});
+/* Since the word field is not non-accented yet,
+ * a strict regex search for words has to be used as a workaround */
+export const searchIgboQuery = (word) => ({
+  word: createRegExp(word, true),
 });
 export const searchEnglishRegexQuery = definitionsQuery;
 export const searchForLastWeekQuery = () => ({

--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -14,7 +14,7 @@ import {
   handleQueries,
   updateDocumentMerge,
 } from './utils';
-import { searchIgboRegexQuery, searchEnglishRegexQuery } from './utils/queries';
+import { searchIgboRegexQuery, searchIgboQuery, searchEnglishRegexQuery } from './utils/queries';
 import { findWordsWithMatch } from './utils/buildDocs';
 import { createExample, executeMergeExample } from './examples';
 import { findGenericWordById } from './genericWords';
@@ -55,19 +55,20 @@ export const getWords = async (req, res) => {
       range,
       skip,
       limit,
+      strict,
       ...rest
     } = handleQueries(req);
     const searchQueries = { searchWord, skip, limit };
-    let regexMatch = searchIgboRegexQuery(regexKeyword);
-    const words = await searchWordUsingIgbo({ query: regexMatch, ...searchQueries });
+    let query = !strict ? searchIgboRegexQuery(regexKeyword) : searchIgboQuery(searchWord);
+    const words = await searchWordUsingIgbo({ query, ...searchQueries });
     if (!words.length) {
-      regexMatch = searchEnglishRegexQuery(regexKeyword);
-      const englishWords = await searchWordUsingEnglish({ query: regexMatch, ...searchQueries });
+      query = searchEnglishRegexQuery(regexKeyword);
+      const englishWords = await searchWordUsingEnglish({ query, ...searchQueries });
       return packageResponse({
         res,
         docs: englishWords,
         model: Word,
-        query: regexMatch,
+        query,
         ...rest,
       });
     }
@@ -75,7 +76,7 @@ export const getWords = async (req, res) => {
       res,
       docs: words,
       model: Word,
-      query: regexMatch,
+      query,
       ...rest,
     });
   } catch (err) {

--- a/src/shared/utils/createRegExp.js
+++ b/src/shared/utils/createRegExp.js
@@ -1,11 +1,12 @@
 import diacriticCodes from '../constants/diacriticCodes';
 
-export default (searchWord) => {
-  /* front and back ensure the regexp will match with whole words */
+export default (searchWord, hardMatch = false) => {
+  /* Front and back ensure the regexp will match with whole words */
   const front = '(?:^|[^a-zA-Z\u00c0-\u1ee5])';
   const back = '(?![a-zA-Z\u00c0-\u1ee5]+|,|s[a-zA-Z\u00c0-\u1ee5]+)';
   const regexWordString = [...searchWord].reduce((regexWord, letter) => (
     `${regexWord}${diacriticCodes[letter] || letter}`
   ), '');
-  return new RegExp(`${front}${regexWordString}${back}`, 'i');
+  /* Hard match checks to see if the searchWord is the beginning and end of the line, triggered by strict query */
+  return new RegExp(!hardMatch ? `${front}${regexWordString}${back}` : `^${front}${regexWordString}${back}$`, 'i');
 };

--- a/swagger.json
+++ b/swagger.json
@@ -223,6 +223,13 @@
             "in": "query",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "strict",
+            "description": "Searches for matching words that start and end with the provided keyword's letters",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "responses": {

--- a/tests/api-mongo.test.js
+++ b/tests/api-mongo.test.js
@@ -705,6 +705,35 @@ describe('MongoDB Words', () => {
           done();
         });
     });
+
+    it('should return hard matched words with strict query', (done) => {
+      const keyword = 'akwa';
+      getWords({ keyword, strict: true })
+        .end((_, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body).to.have.lengthOf.at.least(2);
+          forEach(res.body, (word) => {
+            const wordRegex = createRegExp(word.word);
+            expect(word.word).to.match(wordRegex);
+            expect(word.word.length).to.equal(keyword.length);
+          });
+          done();
+        });
+    });
+
+    it('should return loosely matched words without strict query', (done) => {
+      const keyword = 'akwa';
+      getWords({ keyword, strict: false })
+        .end((_, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body).to.have.lengthOf.at.least(4);
+          forEach(res.body, (word) => {
+            const wordRegex = createRegExp(word.word);
+            expect(word.word).to.match(wordRegex);
+          });
+          done();
+        });
+    });
   });
 });
 


### PR DESCRIPTION
When the `strict` query is provided with the value of `'true'` the API will perform a whole word match with the generated regex.