### PR TITLE
Update fallback regex query

### DIFF
--- a/src/controllers/utils/index.js
+++ b/src/controllers/utils/index.js
@@ -32,7 +32,7 @@ const constructRegexQuery = ({ user, searchWord }) => (
     ? createQueryRegex(searchWord)
     : searchWord
       ? createQueryRegex(searchWord)
-      : /^[.{0,}\n{0,}]/
+      : /.{0,}/
 );
 
 /* Given a list of keys, where each key's value is a list of Firebase uids,


### PR DESCRIPTION
The currently used fallback regex wasn't returning all words and examples. This PR fixes that issue by returning a more loose regex search query.