### PR TITLE
Combine deleted words

### DIFF
--- a/src/controllers/users.js
+++ b/src/controllers/users.js
@@ -23,15 +23,14 @@ export const findUsers = async () => {
 };
 
 /* Grab all users in the Firebase database */
-export const getUsers = async (_, res) => {
+export const getUsers = async (_, res, next) => {
   try {
     const users = await findUsers();
     res.setHeader('Content-Range', users.length);
     res.status(200);
-    res.send(users);
+    return res.send(users);
   } catch {
-    res.status(400);
-    res.send({ error: 'An error occurred while grabbing all users' });
+    return next(new Error('An error occurred while grabbing all users'));
   }
 };
 
@@ -46,15 +45,14 @@ export const findUser = async (uid) => {
 };
 
 /* Grab a single user from the Firebase dataabase */
-export const getUser = async (req, res) => {
+export const getUser = async (req, res, next) => {
   try {
     const { uid } = req.params;
     const user = await findUser(uid);
     res.status(200);
-    res.send(user);
+    return res.send(user);
   } catch {
-    res.status(400);
-    res.send({ error: 'An error occurred while grabbing a single user' });
+    return next(new Error('An error occurred while grabbing a single user'));
   }
 };
 

--- a/src/controllers/utils/index.js
+++ b/src/controllers/utils/index.js
@@ -103,15 +103,10 @@ export const packageResponse = async ({
   query,
   sort,
 }) => {
-  try {
-    const sendDocs = sort ? orderBy(docs, [sort.key], [sort.direction]) : docs;
-    const count = await model.countDocuments(query);
-    res.setHeader('Content-Range', count);
-    return res.send(sendDocs);
-  } catch (err) {
-    res.status(400);
-    return res.send({ error: err.message });
-  }
+  const sendDocs = sort ? orderBy(docs, [sort.key], [sort.direction]) : docs;
+  const count = await model.countDocuments(query);
+  res.setHeader('Content-Range', count);
+  return res.send(sendDocs);
 };
 
 /* Converts the filter query into a word to be used as the keyword query */

--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -1,4 +1,9 @@
-import { assign, map, filter } from 'lodash';
+import {
+  assign,
+  map,
+  filter,
+  uniqBy,
+} from 'lodash';
 import mongoose from 'mongoose';
 import removePrefix from '../shared/utils/removePrefix';
 import Word from '../models/Word';
@@ -16,21 +21,26 @@ import {
 } from './utils';
 import { searchIgboTextSearch, strictSearchIgboQuery, searchEnglishRegexQuery } from './utils/queries';
 import { findWordsWithMatch } from './utils/buildDocs';
-import { createExample, executeMergeExample } from './examples';
+import { createExample, executeMergeExample, findExampleByAssociatedWordId } from './examples';
+import { findGenericWordById } from './genericWords';
+import { findWordSuggestionById } from './wordSuggestions';
 import { sendMergedEmail } from './email';
 import { DICTIONARY_APP_URL } from '../config';
 import { findUser } from './users';
 
 /* Gets words from JSON dictionary */
-export const getWordData = (req, res) => {
-  const { keyword } = req.query;
-  const searchWord = removePrefix(keyword);
-  if (!searchWord) {
-    res.status(400);
-    res.send(NO_PROVIDED_TERM);
+export const getWordData = (req, res, next) => {
+  try {
+    const { keyword } = req.query;
+    const searchWord = removePrefix(keyword);
+    if (!searchWord) {
+      throw new Error(NO_PROVIDED_TERM);
+    }
+    const regexWord = createRegExp(searchWord);
+    return res.send(findSearchWord(regexWord, searchWord));
+  } catch (err) {
+    return next(err);
   }
-  const regexWord = createRegExp(searchWord);
-  return res.send(findSearchWord(regexWord, searchWord));
 };
 
 /* Searches for a word with Igbo stored in MongoDB */
@@ -46,7 +56,7 @@ export const searchWordUsingEnglish = async ({ query, searchWord, ...rest }) => 
 };
 
 /* Gets words from MongoDB */
-export const getWords = async (req, res) => {
+export const getWords = async (req, res, next) => {
   try {
     const {
       searchWord,
@@ -79,27 +89,26 @@ export const getWords = async (req, res) => {
       ...rest,
     });
   } catch (err) {
-    res.status(400);
-    return res.send({ error: err.message });
+    return next(err);
   }
 };
 
 /* Returns a word from MongoDB using an id */
-export const getWord = (req, res) => {
-  const { id } = req.params;
+export const getWord = async (req, res, next) => {
+  try {
+    const { id } = req.params;
 
-  return findWordsWithMatch({ match: { _id: mongoose.Types.ObjectId(id) }, limit: 1 })
-    .then(async ([word]) => {
-      if (!word) {
-        res.status(400);
-        return res.send({ error: 'No word exists with the provided id.' });
-      }
-      return res.send(word);
-    })
-    .catch(() => {
-      res.status(400);
-      return res.send({ error: 'An error has occurred while returning a single word.' });
-    });
+    const updatedWord = await findWordsWithMatch({ match: { _id: mongoose.Types.ObjectId(id) }, limit: 1 })
+      .then(async ([word]) => {
+        if (!word) {
+          throw new Error('No word exists with the provided id.');
+        }
+        return word;
+      });
+    return res.send(updatedWord);
+  } catch (err) {
+    return next(err);
+  }
 };
 
 /* Creates Word documents in MongoDB database */
@@ -203,7 +212,7 @@ const handleSendingMergedEmail = async (result) => {
 
 /* Merges the existing WordSuggestion of GenericWord into either a brand
  * new Word document or merges into an existing Word document */
-export const mergeWord = async (req, res) => {
+export const mergeWord = async (req, res, next) => {
   try {
     const { user, suggestionDoc } = req;
 
@@ -212,30 +221,92 @@ export const mergeWord = async (req, res) => {
       : await createWordFromSuggestion(suggestionDoc, user.uid);
     await handleSendingMergedEmail(result);
     return res.send(result);
-  } catch (error) {
-    return res.send({ error: error.message });
+  } catch (err) {
+    return next(err);
   }
 };
 
-/* Updates a Word document in the database */
-export const putWord = (req, res) => {
-  const { body: data, params: { id } } = req;
-  if (!data.word) {
-    res.status(400);
-    return res.send({ error: 'Required information is missing, double your provided data.' });
+const findAndUpdateWord = (id, cb) => {
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    throw new Error(!id ? 'No word id provided' : 'Invalid word id provided');
   }
 
   return Word.findById(id)
     .then(async (word) => {
       if (!word) {
-        res.status(400);
-        return res.send({ error: 'Word doesn\'t exist' });
+        throw new Error('Word doesn\'t exist');
       }
-      const updatedWord = assign(word, data);
-      return res.send(await updatedWord.save());
-    })
-    .catch(() => {
-      res.status(400);
-      return res.send({ error: 'An error has occurred while updating the word, double check your provided data.' });
+      return cb(assign(word));
     });
+};
+
+/* Updates a Word document in the database */
+export const putWord = async (req, res, next) => {
+  try {
+    const { body: data, params: { id } } = req;
+    if (!data.word) {
+      throw new Error('Required information is missing, double your provided data.');
+    }
+
+    const savedWord = await findAndUpdateWord(id, (word) => {
+      const updatedWord = assign(word, data);
+      return updatedWord.save();
+    });
+    return res.send(savedWord);
+  } catch (err) {
+    return next(err);
+  }
+};
+
+/* Replaces all instances of oldId inside all of the examples with
+ * with the newId */
+const replaceWordIdsFromExampleAssociatedWords = (examples, oldId, newId) => (
+  Promise.all(map(examples, (example) => {
+    const cleanedWordExample = assign(example);
+    cleanedWordExample.associatedWords.push(newId);
+    cleanedWordExample.associatedWords = uniqBy(
+      filter(cleanedWordExample.associatedWords, (associatedWord) => associatedWord.toString() !== oldId.toString()),
+      (associatedWord) => associatedWord.toString(),
+    );
+    return cleanedWordExample.save();
+  }))
+);
+
+/* Deletes the specified Word document while moving its contents
+ * to another Word document, which preserves the original Word
+ * document's data */
+export const deleteWord = async (req, res, next) => {
+  try {
+    const { body: data, params: { id: toBeDeletedWordId } } = req;
+    const { primaryWordId } = data;
+
+    const {
+      word,
+      definitions = [],
+      variations = [],
+      stems = [],
+    } = await Word.findById(toBeDeletedWordId);
+    const toBeDeletedWordExamples = await findExampleByAssociatedWordId(toBeDeletedWordId);
+    const savedCombinedWord = await findAndUpdateWord(primaryWordId, async (combineWord) => {
+      const updatedWord = assign(combineWord);
+      updatedWord.definitions = uniqBy(
+        [...(updatedWord.definitions || []), ...(definitions || [])],
+        (definition) => definition,
+      );
+      updatedWord.variations = uniqBy(
+        [...(updatedWord.variations || []), ...(variations || []), word],
+        (variation) => variation,
+      );
+      updatedWord.stems = uniqBy([...(updatedWord.stems || []), ...(stems || [])], (stem) => stem);
+
+      // Deletes the specified word
+      await Word.deleteOne({ _id: toBeDeletedWordId });
+      await replaceWordIdsFromExampleAssociatedWords(toBeDeletedWordExamples, toBeDeletedWordId, primaryWordId);
+      // Returns the result
+      return updatedWord.save();
+    });
+    return res.send(savedCombinedWord);
+  } catch (err) {
+    return next(err);
+  }
 };

--- a/src/dictionaries/seed.js
+++ b/src/dictionaries/seed.js
@@ -56,12 +56,11 @@ const seed = () => {
   }
 };
 
-export const seedDatabase = async (_, res) => {
+export const seedDatabase = async (_, res, next) => {
   try {
     seed();
     return res.redirect('/');
   } catch (err) {
-    res.status(400);
-    return res.send('An error occurred during seeding');
+    return next(new Error('An error occurred during seeding'));
   }
 };

--- a/src/middleware/authorization.js
+++ b/src/middleware/authorization.js
@@ -6,16 +6,18 @@ const authorization = (permittedRoles = []) => (req, res, next) => {
 
   /* As long as the user has a valid Firebase uid then they have access */
   if (!permittedRoles.length && user.uid) {
-    next();
-  } else if ((user && permittedRoles.includes(user.role)) || user.role === UserRoles.ADMIN) {
+    return next();
+  }
+
+  if ((user && permittedRoles.includes(user.role)) || user.role === UserRoles.ADMIN) {
     /* If the user's role is found in the array of permitted roles,
     * the user is granted access
     */
-    next();
-  } else {
-    res.status(403);
-    res.send({ error: 'Unauthorized. Invalid user permissions.' });
+    return next();
   }
+
+  res.status(403);
+  return res.send({ error: 'Unauthorized. Invalid user permissions.' });
 };
 
 export default authorization;

--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -1,0 +1,12 @@
+// eslint-disable-next-line
+export default (err, req, res, next) => {
+  res.status(400);
+  /* Depending on the nested error message the status code will change */
+  if (err.message.match(/No .{1,} exist(s)?/) || err.message.match(/doesn't exist(s)?/)) {
+    res.status(404);
+  }
+  if (process.env.NODE_ENV === 'development') {
+    console.log(err?.stack);
+  }
+  return res.send({ error: err.message });
+};

--- a/src/middleware/validId.js
+++ b/src/middleware/validId.js
@@ -1,10 +1,15 @@
 import mongoose from 'mongoose';
 
 export default (req, res, next) => {
-  const { id } = req.params;
-  if (!mongoose.Types.ObjectId.isValid(id)) {
+  try {
+    const { id } = req.params;
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      res.status(400);
+      return res.send({ error: 'Provided an invalid id' });
+    }
+    return next();
+  } catch (err) {
     res.status(400);
-    return res.send({ error: 'Provided an invalid id' });
+    return res.send({ error: err.message });
   }
-  return next();
 };

--- a/src/routers/editorRouter.js
+++ b/src/routers/editorRouter.js
@@ -5,7 +5,7 @@ import {
   getWordSuggestions,
   putWordSuggestion,
 } from '../controllers/wordSuggestions';
-import { putWord, mergeWord } from '../controllers/words';
+import { deleteWord, putWord, mergeWord } from '../controllers/words';
 import { putExample, mergeExample } from '../controllers/examples';
 import {
   deleteExampleSuggestion,
@@ -33,6 +33,8 @@ const editorRouter = express.Router();
 /* These routes are used to allow users to suggest new words and examples */
 editorRouter.post('/words', authorization([UserRoles.MERGER, UserRoles.ADMIN]), validateWordMerge, mergeWord);
 editorRouter.put('/words/:id', validId, authorization([UserRoles.MERGER, UserRoles.ADMIN]), putWord);
+editorRouter.delete('/words/:id', validId, authorization([UserRoles.MERGER, UserRoles.ADMIN]), deleteWord);
+
 editorRouter.post('/examples', authorization([UserRoles.MERGER, UserRoles.ADMIN]), validateExampleMerge, mergeExample);
 editorRouter.put('/examples/:id', validId, authorization([UserRoles.MERGER, UserRoles.ADMIN]), putExample);
 

--- a/src/server.js
+++ b/src/server.js
@@ -18,6 +18,7 @@ import {
 import logger from './middleware/logger';
 import authentication from './middleware/authentication';
 import authorization from './middleware/authorization';
+import errorHandler from './middleware/errorHandler';
 import {
   PORT,
   MONGO_URI,
@@ -94,11 +95,13 @@ if (process.env.NODE_ENV !== 'production') {
   );
 }
 
+/* Catches all invalid routes and displays the 404 page */
 app.get('*', (_, res) => {
   res
     .status(404)
     .sendFile(path.resolve(__dirname, 'dist/404.html'));
 });
+app.use(errorHandler);
 
 const server = app.listen(PORT, () => {
   console.green(`🟢 Server started on port ${PORT}`);

--- a/tests/api-json.test.js
+++ b/tests/api-json.test.js
@@ -41,7 +41,7 @@ describe('JSON Dictionary', () => {
     it('should return an error for searching no word', (done) => {
       searchTerm().end((_, res) => {
         expect(res.status).to.equal(400);
-        expect(res.text).to.equal(NO_PROVIDED_TERM);
+        expect(res.body.error).to.equal(NO_PROVIDED_TERM);
         done();
       });
     });

--- a/tests/exampleSuggestions.test.js
+++ b/tests/exampleSuggestions.test.js
@@ -382,7 +382,7 @@ describe('MongoDB Example Suggestions', () => {
               expect(deleteRes.status).to.equal(200);
               getExampleSuggestion(firstExample.id)
                 .end((_, searchExampleRes) => {
-                  expect(searchExampleRes.status).to.equal(400);
+                  expect(searchExampleRes.status).to.equal(404);
                   expect(searchExampleRes.body.error).to.not.equal(undefined);
                   done();
                 });

--- a/tests/genericWords.test.js
+++ b/tests/genericWords.test.js
@@ -153,7 +153,7 @@ describe('MongoDB Generic Words', () => {
         .then(() => {
           getGenericWord(NONEXISTENT_ID)
             .end((_, result) => {
-              expect(result.status).to.equal(400);
+              expect(result.status).to.equal(404);
               expect(result.error).to.not.equal(undefined);
               done();
             });
@@ -312,7 +312,7 @@ describe('MongoDB Generic Words', () => {
               expect(deleteRes.status).to.equal(200);
               getGenericWord(firstGenericWord.id)
                 .end((_, searchGenericWordRes) => {
-                  expect(searchGenericWordRes.status).to.equal(400);
+                  expect(searchGenericWordRes.status).to.equal(404);
                   expect(searchGenericWordRes.body.error).to.not.equal(undefined);
                   done();
                 });

--- a/tests/shared/commands.js
+++ b/tests/shared/commands.js
@@ -77,6 +77,13 @@ export const createWord = (id, query = {}) => (
     .send({ id })
 );
 
+export const deleteWord = (id, primaryWordId) => (
+  chai
+    .request(server)
+    .delete(`${API_ROUTE}/words/${id}`)
+    .send({ primaryWordId })
+);
+
 export const createExample = (id, query = {}) => (
   chai
     .request(server)

--- a/tests/shared/utils.js
+++ b/tests/shared/utils.js
@@ -4,7 +4,15 @@ import {
   forEach,
   map,
   every,
+  isEqual,
 } from 'lodash';
+import {
+  suggestNewWord,
+  suggestNewExample,
+  createWord,
+  createExample,
+  getWord,
+} from './commands';
 import SortingDirections from '../../src/shared/constants/sortingDirections';
 
 const { expect } = chai;
@@ -35,7 +43,46 @@ const expectArrayIsInOrder = (array, key, direction = SortingDirections.ASCENDIN
   expect(isOrdered).to.equal(true);
 };
 
+const createWordFromSuggestion = (wordSuggestionData) => (
+  suggestNewWord(wordSuggestionData)
+    .then((res) => {
+      expect(res.status).to.equal(200);
+      const mergingWordSuggestion = { ...res.body, ...wordSuggestionData };
+      return createWord(mergingWordSuggestion.id)
+        .then((result) => {
+          expect(result.status).to.equal(200);
+          expect(result.body.id).to.not.equal(undefined);
+          expect(result.body.authorId).to.equal(undefined);
+          return getWord(result.body.id)
+            .then((wordRes) => {
+              expect(wordRes.status).to.equal(200);
+              return wordRes.body;
+            });
+        })
+        .catch((err) => {
+          console.log({ err: err.message });
+        });
+    })
+);
+
+const createExampleFromSuggestion = (exampleSuggestionData) => (
+  suggestNewExample(exampleSuggestionData)
+    .then((exampleSuggestionRes) => {
+      expect(exampleSuggestionRes.status).to.equal(200);
+      return createExample(exampleSuggestionRes.body.id)
+        .then((finalRes) => {
+          expect(isEqual(
+            exampleSuggestionRes.body.associatedWords,
+            finalRes.body.associatedWords,
+          )).to.equal(true);
+          return finalRes.body;
+        });
+    })
+);
+
 export {
   expectUniqSetsOfResponses,
   expectArrayIsInOrder,
+  createWordFromSuggestion,
+  createExampleFromSuggestion,
 };

--- a/tests/wordSuggestions.test.js
+++ b/tests/wordSuggestions.test.js
@@ -148,7 +148,7 @@ describe('MongoDB Word Suggestions', () => {
               expect(result.body.examples).to.have.lengthOf(0);
               getExampleSuggestion(exampleSuggestionToDeleteId)
                 .end((_, noExampleSuggestionRes) => {
-                  expect(noExampleSuggestionRes.status).to.equal(400);
+                  expect(noExampleSuggestionRes.status).to.equal(404);
                   expect(noExampleSuggestionRes.body.error).to.not.equal(undefined);
                   done();
                 });
@@ -444,7 +444,7 @@ describe('MongoDB Word Suggestions', () => {
               expect(result.body.id).to.not.equal(undefined);
               getWordSuggestion(result.body.id)
                 .end((_, resError) => {
-                  expect(resError.status).to.equal(400);
+                  expect(resError.status).to.equal(404);
                   expect(resError.body.error).to.not.equal(undefined);
                   done();
                 });
@@ -463,7 +463,7 @@ describe('MongoDB Word Suggestions', () => {
     it('should return error for non existent word suggestion', (done) => {
       getWordSuggestion(wordSuggestionId)
         .end((_, res) => {
-          expect(res.status).to.equal(400);
+          expect(res.status).to.equal(404);
           expect(res.body.error).to.not.equal(undefined);
           done();
         });


### PR DESCRIPTION
The API shouldn't have the ability to delete word documents at this moment. Instead, if a word document should be "deleted" it should be combined into another word document. This approach is better since it preserves the soon-to-be-deleted word's information.

This PR:
* Updates existing tests to handle new middleware
* Creates a new Express error handler middleware

Closes #294
