### PR TITLE
Terminate server after seeding database so Docker can automatically restart the server container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - 27017:27017
   server:
     container_name: igbo_api_server
-    restart: on-failure
+    restart: always
     build: .
     image: ijemmao/igbo_api_server
     ports:

--- a/src/controllers/genericWords.js
+++ b/src/controllers/genericWords.js
@@ -140,9 +140,12 @@ export const createGenericWords = async (_, res, next) => {
     const dictionary = process.env.NODE_ENV === 'test' ? testGenericWordsDictionary : genericWordsDictionary;
     const genericWordsPromises = await seedGenericWords(dictionary);
     const genericWords = await Promise.all(genericWordsPromises)
-      .then(() => (
-        res.send({ message: 'Successfully populated generic words' })
-      ));
+      .then(() => {
+        if (process.env.NODE_ENV !== 'production') {
+          console.green('✅ Seeding successful');
+        }
+        return 'Successfully populated generic words';
+      });
     return res.send(genericWords);
   } catch (err) {
     return next(err);

--- a/tests/api-json.test.js
+++ b/tests/api-json.test.js
@@ -16,7 +16,7 @@ chai.use(chaiHttp);
 
 describe('JSON Dictionary', () => {
   before(function (done) {
-    this.timeout(60000);
+    this.timeout(120000);
     server.clearDatabase();
     Promise.all([
       populateAPI(),

--- a/tests/api-json.test.js
+++ b/tests/api-json.test.js
@@ -18,12 +18,13 @@ describe('JSON Dictionary', () => {
   before(function (done) {
     this.timeout(120000);
     server.clearDatabase();
-    Promise.all([
-      populateAPI(),
-      populateGenericWordsAPI(),
-    ]).then(() => {
-      setTimeout(() => done(), 30000);
-    });
+    populateAPI()
+      .then(() => {
+        populateGenericWordsAPI()
+          .end(() => {
+            setTimeout(() => done(), 10000);
+          });
+      });
   });
 
   describe('/GET words', () => {

--- a/tests/shared/utils.js
+++ b/tests/shared/utils.js
@@ -59,9 +59,7 @@ const createWordFromSuggestion = (wordSuggestionData) => (
               return wordRes.body;
             });
         })
-        .catch((err) => {
-          console.log({ err: err.message });
-        });
+        .catch(() => {});
     })
 );
 


### PR DESCRIPTION
Due to MongoDB Text Indexes not created properly while the server is up, the server needs to be restarted in order for the database to detect that new text indexes have been created.

Restarted the database to detect new text indexes is only necessary inside a Docker container since the Docker container doesn't recognize that the server needs to be restarted in order to see text indexes.

## Solution
This PR checks to see if the server is running in a Docker container. If it is, then it will redirect the client back to the homepage of the API and then wait two seconds to close the instance of the server. Docker will automatically restart the server because of the docker-compose's `restart: always` option