### PR TITLE
Delete orphan word suggestions

### DIFF
--- a/src/controllers/wordSuggestions.js
+++ b/src/controllers/wordSuggestions.js
@@ -46,6 +46,10 @@ export const findWordSuggestionById = (id) => (
   WordSuggestion.findById(id)
 );
 
+export const deleteWordSuggestionsByOriginalWordId = (id) => (
+  WordSuggestion.deleteMany({ originalWordId: id })
+);
+
 /* Grabs WordSuggestions and sorts them by their last update in descending order */
 const findWordSuggestions = async ({ regexMatch, skip, limit }) => (
   WordSuggestion

--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -22,8 +22,7 @@ import {
 import { searchIgboTextSearch, strictSearchIgboQuery, searchEnglishRegexQuery } from './utils/queries';
 import { findWordsWithMatch } from './utils/buildDocs';
 import { createExample, executeMergeExample, findExampleByAssociatedWordId } from './examples';
-import { findGenericWordById } from './genericWords';
-import { findWordSuggestionById } from './wordSuggestions';
+import { deleteWordSuggestionsByOriginalWordId } from './wordSuggestions';
 import { sendMergedEmail } from './email';
 import { DICTIONARY_APP_URL } from '../config';
 import { findUser } from './users';
@@ -299,8 +298,9 @@ export const deleteWord = async (req, res, next) => {
       );
       updatedWord.stems = uniqBy([...(updatedWord.stems || []), ...(stems || [])], (stem) => stem);
 
-      // Deletes the specified word
+      /* Deletes the specified word and connected wordSuggestions regardless of their merged status */
       await Word.deleteOne({ _id: toBeDeletedWordId });
+      await deleteWordSuggestionsByOriginalWordId(toBeDeletedWordId);
       await replaceWordIdsFromExampleAssociatedWords(toBeDeletedWordExamples, toBeDeletedWordId, primaryWordId);
       // Returns the result
       return updatedWord.save();


### PR DESCRIPTION
When a word document gets combined into another word document, it has essentially been deleted from the database. This leaves wordSuggestions with an existing `originalWordId` "orphaned" if their `originalWordId` was pointing to the recently deleted word document.

This PR adds the functionality of finding all wordSuggestions with their `originalWordId` pointing to the recently deleted word document and deleted those wordSuggestions.

**Note: This will delete all associated wordSuggestions, merged or not.**