### PR TITLE
Remove open CORS policy for production apps

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -23,7 +23,7 @@ export const MONGO_URI = process.env.NODE_ENV === 'test'
   : process.env.NODE_ENV === 'development'
     ? LOCAL_MONGO_URI
     : process.env.MONGO_URI || LOCAL_MONGO_URI;
-const PROD_CORS_ORIGINS = [/\.igboapi\.com$/, /nkowaokwu\.com$/, /igbo-api-admin.web.app$/];
+const PROD_CORS_ORIGINS = [/localhost/, /\.igboapi\.com$/, /nkowaokwu\.com$/, /igbo-api-admin.web.app$/];
 /* Prevents non-approved cross-origin sites from accessing certain routes */
 export const CORS_CONFIG = {
   origin: process.env.NODE_ENV === 'production' ? PROD_CORS_ORIGINS : true,

--- a/src/pages/App.js
+++ b/src/pages/App.js
@@ -63,12 +63,14 @@ const App = () => (
         <h2 className="header">Docs</h2>
       </div>
       <div className="flex flex-col mb-12">
-        <p className="text-2xl text-center text-gray-700 w-9/12 md:w-1/2 self-center mb-24">
+        <p className="text-2xl text-center text-gray-700 w-9/12 md:w-1/2 self-center mb-12">
           {'Are you a developer interested in using the API? Head over to the '}
-          <a className="link" href={`${API_ROUTE}/docs`}>
-            docs
-          </a>
+          <a className="link" href={`${API_ROUTE}/docs`}>docs</a>
           {' to get started.'}
+        </p>
+        <p className="text-2xl text-center text-gray-700 w-9/12 md:w-1/2 self-center mb-24">
+          {'If you would like to use this API for production purposes, request access by sending us an email at '}
+          <a className="link" href={`mailto:${API_FROM_EMAIL}`}>{API_FROM_EMAIL}</a>
         </p>
       </div>
       <footer className={`flex flex-col text-center lg:text-left lg:flex-row

--- a/src/server.js
+++ b/src/server.js
@@ -75,7 +75,7 @@ app.get('/', (_, res) => {
 app.use('/docs', swaggerUI.serve, swaggerUI.setup(SWAGGER_DOCS));
 
 /* Grabs data from MongoDB */
-app.use('/api/v1', cors({ ...CORS_CONFIG, origin: true }), authentication, router);
+app.use('/api/v1', cors(CORS_CONFIG), authentication, router);
 app.use('/api/v1',
   cors(CORS_CONFIG),
   authentication,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,9 +1,15 @@
 module.exports = {
   future: {
-    // removeDeprecatedGapUtilities: true,
-    // purgeLayersByDefault: true,
+    removeDeprecatedGapUtilities: true,
+    purgeLayersByDefault: true,
   },
-  purge: [],
+  purge: {
+    enabled: true,
+    content: [
+      './src/**/*.js',
+      './public/**/*.html',
+    ],
+  },
   theme: {
     extend: {},
   },


### PR DESCRIPTION
Removing the open CORS policy for developments. This means if a developer wants to use the API right now, they would need to run the API locally or request access to the API by sending an email to igboapi@gmail.

This PR also:
* Purges unused CSS styles to make total bundle size smaller