### PR TITLE
Land at the top of the page on first load

### DIFF
--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export default () => <div>whoops</div>;

--- a/src/pages/components/Demo/Demo.js
+++ b/src/pages/components/Demo/Demo.js
@@ -9,11 +9,11 @@ const Demo = ({ searchWord, words }) => {
   const responseBody = JSON.stringify(words, null, 4);
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
+    if (typeof window !== 'undefined' && keyword) {
       setProductionUrl(window.origin);
       window.location.hash = 'try-it-out';
     }
-  });
+  }, []);
 
   const onSubmit = (e) => {
     e?.preventDefault();

--- a/src/pages/components/Navbar/Navbar.js
+++ b/src/pages/components/Navbar/Navbar.js
@@ -4,9 +4,8 @@ import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { Link } from 'react-scroll';
 import SubMenu from './SubMenu';
 import downchevron from '../../assets/downchevron.svg';
-import { API_ROUTE } from '../../../siteConstants';
 
-const menuIcon = process.env.NODE_ENV !== 'production' ? downchevron : `${API_ROUTE}/assets/downchevron.svg`;
+const menuIcon = process.env.NODE_ENV !== 'production' ? downchevron : '/assets/downchevron.svg';
 
 const Navbar = ({ to, isHomepage, transparent }) => {
   const [isMenuVisible, setIsMenuVisible] = useState(false);

--- a/src/server.js
+++ b/src/server.js
@@ -58,7 +58,10 @@ if (process.env.NODE_ENV === 'development') {
 
 app.options('*', cors());
 
+/* Provides static assets for the API Homepage */
 app.use('/_next', express.static('./build/dist'));
+app.use('/assets', express.static('./build/dist/assets'));
+app.use('/fonts', express.static('./build/dist/fonts'));
 
 /* Renders the API Site */
 app.use(siteRouter);

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,4 @@
 import express from 'express';
-import path from 'path';
 import mongoose from 'mongoose';
 import cors from 'cors';
 import bodyParser from 'body-parser';
@@ -80,11 +79,9 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 /* Catches all invalid routes and displays the 404 page */
-app.get('**', (_, res) => {
-  res
-    .status(404)
-    .sendFile(path.resolve(__dirname, './dist/404.html'));
-});
+app.get('**', (_, res) => (
+  res.redirect('/')
+));
 app.use(errorHandler);
 
 const server = app.listen(PORT, () => {

--- a/tests/homepage.test.js
+++ b/tests/homepage.test.js
@@ -1,5 +1,5 @@
 import chai from 'chai';
-import { getAPIUrlRoute, getLocalUrlRoute } from './shared/commands';
+import { getLocalUrlRoute } from './shared/commands';
 import { SITE_TITLE, DOCS_SITE_TITLE } from './shared/constants';
 
 const { expect } = chai;
@@ -28,29 +28,6 @@ describe('API Homepage', () => {
         expect(res.body).to.be.an('object');
         expect(res.text).to.not.contain('An unexpected error has occurred.');
         expect(res.text).to.contain(DOCS_SITE_TITLE);
-        done();
-      });
-  });
-});
-
-describe('API Requests For Home Directory \'/\'', () => {
-  it('should return response status of 404 in /undefinedRoute', (done) => {
-    const route = '/undefinedRoute';
-    getAPIUrlRoute(route)
-      .end((_, res) => {
-        expect(res.status).to.equal(404);
-        done();
-      });
-  });
-
-  it('should contain Igbo API in / route', (done) => {
-    getAPIUrlRoute()
-      .end((_, res) => {
-        expect(res.status).to.equal(200);
-        expect(res.type).to.equal('text/html');
-        expect(res.charset.toLowerCase()).to.equal('utf-8');
-        expect(res.body).to.be.an('object');
-        expect(res.text).to.contain(SITE_TITLE);
         done();
       });
   });

--- a/tests/shared/commands.js
+++ b/tests/shared/commands.js
@@ -3,7 +3,6 @@ import server from '../../src/server';
 import {
   API_ROUTE,
   API_KEY,
-  API_URL,
   AUTH_TOKEN,
   ORIGIN_HEADER,
   LOCAL_ROUTE,
@@ -75,12 +74,6 @@ export const searchTerm = (term) => (
     .request(server)
     .get(`${TEST_ROUTE}/words`)
     .query({ keyword: term })
-);
-
-export const getAPIUrlRoute = (route = LOCAL_ROUTE) => (
-  chai
-    .request(API_URL)
-    .get(route)
 );
 
 export const getLocalUrlRoute = (route = LOCAL_ROUTE) => (


### PR DESCRIPTION
The homepage would automatically jump to the Try it Out section when the user first visits the site, which is really confusing.

This PR fixes that bug.

This PR also:
* Remove unit tests that test production code along with the command used in those tests
* Creates a new 404 Not Found
* Redirects users back to the homepage if they provide an invalid route