### PR TITLE
Use HTTPS for docs when deployed

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -34,7 +34,7 @@ const SWAGGER_SETTINGS = {
   version: packageJson.version,
   description: packageJson.description,
   host: `${process.env.HEROKU ? process.env.DOMAIN_NAME : `localhost:${PORT}`}`,
-  basePath: '/api/v1/',
+  schemes: `${process.env.HEROKU ? ['https'] : ['http']}`,
 };
 
 const docs = { ...swaggerConfig, ...SWAGGER_SETTINGS };

--- a/swagger.json
+++ b/swagger.json
@@ -10,7 +10,7 @@
     }
   },
   "host": "localhost:8080",
-  "basePath": "/api/v1",
+  "basePath": "/api/v1/",
   "tags": [
     {
       "name": "Production",


### PR DESCRIPTION
The docs in production are unable to make successful requests since it was making HTTP protocol requests instead of HTTPS.