### PR TITLE
Allow Docker consumers to change NODE_ENV variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ COPY . .
 RUN yarn build
 
 ENV PORT=8080
-ENV NODE_ENV=test
 ENV CONTAINER_HOST=mongodb
 
 EXPOSE 8080

--- a/src/config.js
+++ b/src/config.js
@@ -12,12 +12,21 @@ if (dotenv) {
 const DB_NAME = 'igbo_api';
 const TEST_DB_NAME = 'test_igbo_api';
 
+// If running inside Docker container, it will fallback to using test_igbo_api database
+const isTestingEnvironment = (
+  process.env.NODE_ENV === 'test'
+  || (
+    process.env.CONTAINER_HOST === 'mongodb'
+    && process.env.NODE_ENV !== 'development'
+    && process.env.NODE_ENV !== 'production'
+  )
+);
 export const PORT = process.env.PORT || 8080;
 export const MONGO_HOST = process.env.CONTAINER_HOST || 'localhost';
 export const MONGO_ROOT = `mongodb://${MONGO_HOST}:27017`;
 const TEST_MONGO_URI = `${MONGO_ROOT}/${TEST_DB_NAME}`;
 const LOCAL_MONGO_URI = `${MONGO_ROOT}/${DB_NAME}`;
-export const MONGO_URI = process.env.NODE_ENV === 'test'
+export const MONGO_URI = isTestingEnvironment
   ? TEST_MONGO_URI
   : process.env.NODE_ENV === 'development'
     ? LOCAL_MONGO_URI


### PR DESCRIPTION
When a new Docker container was created with this project's Docker file, the environment would automatically assume it's running in a testing environment by setting `NODE_ENV` to `test` in the Dockerfile.

However, the Dockerfile should be responsible for setting the environment variable. Instead, the application that creates the container with the Dockerfile should have the ability to set `NODE_ENV`. This PR changes the Dockerfile and `config.js` to make it possible to change `NODE_ENV` from outside the container.