### PR TITLE
Remove the conditional purge check

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,13 +3,10 @@ module.exports = {
     removeDeprecatedGapUtilities: true,
     purgeLayersByDefault: true,
   },
-  purge: {
-    enabled: process.env.NODE_ENV === 'production',
-    content: [
-      './src/**/*.js',
-      './public/**/*.html',
-    ],
-  },
+  purge: [
+    './src/**/*.js',
+    './public/**/*.html',
+  ],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Background
Checking whether Tailwind is in a production or development is done automatically by Tailwind, so there's no need for its config to explicitly make the check again

## Solution
Remove the `enabled` field from the `purge` object so the responsibility of determining whether or not to purge styles will be 100% up to Tailwind