### PR TITLE
Dialects for individual words

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+  
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+    - name: Use Node.js v14
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14
+    - name: Install Dependencies
+      run: yarn install
+    - name: Release
+      env:
+        GITHUB_TOKEN: ${{ secrets.RELEASE_ACCESS_TOKEN }}
+      run: npx semantic-release

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
   "engines": {
     "node": ">=10.0.0"
   },
+  "release": {
+    "branches": ["master"]
+  },
   "husky": {
     "hooks": {
       "pre-commit": "yarn precommit",

--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -91,8 +91,9 @@ export const getWords = async (req, res, next) => {
 export const getWord = async (req, res, next) => {
   try {
     const { id } = req.params;
+    const { dialects } = handleQueries(req);
 
-    const updatedWord = await findWordsWithMatch({ match: { _id: mongoose.Types.ObjectId(id) }, limit: 1 })
+    const updatedWord = await findWordsWithMatch({ match: { _id: mongoose.Types.ObjectId(id) }, limit: 1, dialects })
       .then(async ([word]) => {
         if (!word) {
           throw new Error('No word exists with the provided id.');

--- a/tests/cypress/integration/client.test.js
+++ b/tests/cypress/integration/client.test.js
@@ -20,13 +20,15 @@ describe('Igbo API Homepage', () => {
     });
 
     describe('Register Account', () => {
-      it('render the Sign Up page', () => {
+      beforeEach(() => {
         cy.visit('/signup');
+      });
+
+      it('render the Sign Up page', () => {
         cy.findByText('Sign up.');
       });
 
       it('fill out the sign up form and submit for developer account', () => {
-        cy.visit('/signup');
         cy.intercept('POST', '**developers').as('postDeveloper');
         cy.findByTestId('signup-name-input').clear().type('Developer');
         cy.findByTestId('signup-email-input').clear().type('developer@test.com');
@@ -40,7 +42,6 @@ describe('Igbo API Homepage', () => {
       });
 
       it('fill out the sign up form and submit for developer account and get an error', () => {
-        cy.visit('/signup');
         cy.intercept('POST', '**developers').as('postDeveloper');
         cy.findByTestId('signup-name-input').clear().type('Developer');
         cy.findByTestId('signup-email-input').clear().type('developer@example.com');
@@ -70,6 +71,7 @@ describe('Igbo API Homepage', () => {
     it('render the Sign up page', () => {
       cy.findByAltText('down arrow as menu icon').click();
       cy.get('a').contains('Register API Key').click();
+      cy.findByText('Sign up.');
     });
   });
 });


### PR DESCRIPTION
## Background
The `dialects` query param was only working when a request was made searching for a word using the `keyword` query param. `dialects` should also work when an individual word document was requested when a request was made with the word document `id`

This PR also:
* Update the `client.test.js` file to reduce redudant code
* An initial attempt to start using `semantic-release`