### PR TITLE
Alphabetize Word Results

### DIFF
--- a/src/controllers/utils/buildDocs.js
+++ b/src/controllers/utils/buildDocs.js
@@ -27,6 +27,18 @@ const removeKeysInNestedDoc = (docs, nestedDocsKey) => {
   return docs;
 };
 
+/* Depending on whether or not a search term is provided,
+ * the sort by key will be determined */
+const determineSorting = (match) => {
+  if (match.$text) {
+    if (match.$text.$search) {
+      return { word: { $meta: 'textScore' } };
+    }
+    return { word: 1 };
+  }
+  return { 'definitions.0': 1 };
+};
+
 /* Performs a outer left lookup to append associated examples
  * and returns a plain word object, not a Mongoose Query
  */
@@ -38,7 +50,7 @@ export const findWordsWithMatch = async ({
 }) => {
   const words = await Word.aggregate()
     .match(match)
-    .sort(match.$text ? { word: { $meta: 'textScore' } } : { 'definitions.0': 1 })
+    .sort(determineSorting(match))
     .lookup({
       from: 'examples',
       localField: '_id',

--- a/src/controllers/utils/index.js
+++ b/src/controllers/utils/index.js
@@ -159,5 +159,6 @@ export const handleQueries = ({ query = {}, isUsingMainKey }) => {
     limit,
     strict,
     dialects,
+    isUsingMainKey,
   };
 };

--- a/src/controllers/utils/queries.js
+++ b/src/controllers/utils/queries.js
@@ -1,6 +1,9 @@
 import createRegExp from '../../shared/utils/createRegExp';
 
-const fullTextSearchQuery = (keyword) => ({ $text: { $search: keyword } });
+const fullTextSearchQuery = (keyword, isUsingMainKey) => (isUsingMainKey && !keyword
+  ? { word: { $regex: /./ } }
+  : { $text: { $search: keyword } }
+);
 const definitionsQuery = (regex) => ({ definitions: { $in: [regex] } });
 const hostsQuery = (host) => ({ hosts: { $in: [host] } });
 

--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -54,6 +54,7 @@ export const getWords = async (req, res, next) => {
       limit,
       strict,
       dialects,
+      isUsingMainKey,
       ...rest
     } = handleQueries(req);
     const searchQueries = {
@@ -62,7 +63,7 @@ export const getWords = async (req, res, next) => {
       limit,
       dialects,
     };
-    let query = !strict ? searchIgboTextSearch(searchWord) : strictSearchIgboQuery(searchWord);
+    let query = !strict ? searchIgboTextSearch(searchWord, isUsingMainKey) : strictSearchIgboQuery(searchWord);
     const words = await searchWordUsingIgbo({ query, ...searchQueries });
     if (!words.length) {
       query = searchEnglishRegexQuery(regexKeyword);

--- a/tests/api-json.test.js
+++ b/tests/api-json.test.js
@@ -1,12 +1,13 @@
 import chai from 'chai';
 import chaiHttp from 'chai-http';
-import { isEqual } from 'lodash';
+import { isEqual, sortBy } from 'lodash';
 import mongoose from 'mongoose';
 import server from '../src/server';
 import { NO_PROVIDED_TERM } from '../src/shared/constants/errorMessages';
 import {
   populateAPI,
   searchTerm,
+  getWords,
 } from './shared/commands';
 
 const { expect } = chai;
@@ -54,9 +55,19 @@ describe('JSON Dictionary', () => {
     });
 
     it('should return term using variation', (done) => {
-      searchTerm('-mu-mù').end(async (_, res) => {
+      searchTerm('-mu-mù').end((_, res) => {
         expect(res.status).to.equal(200);
         expect(res.body['-mụ-mù']).to.have.lengthOf(1);
+        done();
+      });
+    });
+
+    it('should return words in alphabetical order', (done) => {
+      getWords().end((_, res) => {
+        expect(res.status).to.equal(200);
+        const resWords = res.body.map(({ word }) => word);
+        const sortedWords = sortBy(resWords, [(word) => word]);
+        expect(isEqual(resWords, sortedWords)).to.equal(true);
         done();
       });
     });


### PR DESCRIPTION
## Background
To make it easier for admins to sort through words in the API, the word results will now be in alphabetical order by the headwords **if** the user provided no keyword for the API to use for searching. Since admins are only able to receive words without providing a keyword, this feature will only be available to admins.