### PR TITLE
Add Central Igbo

### DIFF
--- a/migrations/20210325194345-add-central-igbo.js
+++ b/migrations/20210325194345-add-central-igbo.js
@@ -1,0 +1,19 @@
+module.exports = {
+  async up(db) {
+    const collections = ['words', 'wordsuggestions', 'genericwords'];
+    return collections.map((collection) => (
+      db.collection(collection).updateMany({}, {
+        $set: { isCentralIgbo: false },
+      })
+    ));
+  },
+
+  async down(db) {
+    const collections = ['words', 'wordsuggestions', 'genericwords'];
+    return collections.map((collection) => (
+      db.collection(collection).updateMany({}, {
+        $unset: { isCentralIgbo: null },
+      })
+    ));
+  },
+};

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "start:docker": "docker-compose up",
     "test:build": "NODE_ENV=build yarn start",
     "dev:site": "cross-env NODE_ENV=development next",
-    "start:server": "cross-env NODE_ENV=development nodemon --exec babel-node -- ./src/server.js",
+    "start:server": "cross-env NODE_ENV=test nodemon --exec babel-node -- ./src/server.js",
     "start:database": "mongod --dbpath ./db",
     "test": "npm-run-all -p -r start:database mocha"
   },

--- a/src/controllers/utils/buildDocs.js
+++ b/src/controllers/utils/buildDocs.js
@@ -66,7 +66,7 @@ export const findWordsWithMatch = async ({
       definitions: 1,
       variations: 1,
       stems: 1,
-      normalized: 1,
+      normalized: 0,
       examples: 1,
       updatedOn: 1,
       accented: 1,

--- a/src/controllers/utils/buildDocs.js
+++ b/src/controllers/utils/buildDocs.js
@@ -66,7 +66,6 @@ export const findWordsWithMatch = async ({
       definitions: 1,
       variations: 1,
       stems: 1,
-      normalized: 0,
       examples: 1,
       updatedOn: 1,
       accented: 1,

--- a/src/models/Word.js
+++ b/src/models/Word.js
@@ -27,6 +27,7 @@ const wordSchema = new Schema({
       ));
     },
   },
+  isCentralIgbo: { type: Boolean, default: false },
   variations: { type: [{ type: String }], default: [] },
   normalized: { type: String, default: '' },
   frequency: { type: Number },

--- a/tests/shared/constants.js
+++ b/tests/shared/constants.js
@@ -14,7 +14,6 @@ export const WORD_KEYS = [
   'stems',
   'examples',
   'id',
-  'normalized',
   'word',
   'wordClass',
   'updatedOn',


### PR DESCRIPTION
## Background
To keep track of a headword of an entry is in Central Igbo or not, a new `isCentralIgbo` in the word document. This key will not be exposed via the API since it's still experimental.

This PR also:
* Stops sending over `normalized` key since it's always empty. It might be completely deprecated and dropped from the database