### PR TITLE
Ensure consistency sorting order for each get word execution

### DIFF
--- a/src/controllers/utils/buildDocs.js
+++ b/src/controllers/utils/buildDocs.js
@@ -35,7 +35,7 @@ const determineSorting = (match) => {
       return { word: { $meta: 'textScore' } };
     }
   } else if (match.word) {
-    return { word: 1 };
+    return { word: 1, _id: 1 };
   }
   return { 'definitions.0': 1 };
 };


### PR DESCRIPTION
## Background
If there is a case where there are two identical head words, MongoDB will then sort by the secondary `_id` field to make sure that the same sorted order is preserved upon each execution of grabbing words.