### PR TITLE
Name Word Class

### DIFF
--- a/src/shared/constants/wordClass.js
+++ b/src/shared/constants/wordClass.js
@@ -27,6 +27,10 @@ export default {
     value: 'INTJ',
     label: 'Interjection',
   },
+  NM: {
+    value: 'NM',
+    label: 'Name',
+  },
   NNC: {
     value: 'NNC',
     label: 'Common noun',


### PR DESCRIPTION
## Background
The Igbo API can now support the new 'Name' `wordClass`