### PR TITLE
Examples Flag

### DIFF
--- a/src/controllers/utils/index.js
+++ b/src/controllers/utils/index.js
@@ -140,6 +140,7 @@ export const handleQueries = ({ query = {}, isUsingMainKey }) => {
     filter: filterQuery,
     strict: strictQuery,
     dialects: dialectsQuery,
+    examples: examplesQuery,
   } = query;
   const filter = convertFilterToKeyword(filterQuery);
   const searchWord = removePrefix(keyword || filter || '');
@@ -150,6 +151,7 @@ export const handleQueries = ({ query = {}, isUsingMainKey }) => {
   const sort = parseSortKeys(sortQuery);
   const strict = strictQuery === 'true';
   const dialects = dialectsQuery === 'true';
+  const examples = examplesQuery === 'true';
   return {
     searchWord,
     regexKeyword,
@@ -159,6 +161,7 @@ export const handleQueries = ({ query = {}, isUsingMainKey }) => {
     limit,
     strict,
     dialects,
+    examples,
     isUsingMainKey,
   };
 };

--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -49,11 +49,11 @@ export const getWords = async (req, res, next) => {
     const {
       searchWord,
       regexKeyword,
-      range,
       skip,
       limit,
       strict,
       dialects,
+      examples,
       isUsingMainKey,
       ...rest
     } = handleQueries(req);
@@ -62,6 +62,7 @@ export const getWords = async (req, res, next) => {
       skip,
       limit,
       dialects,
+      examples,
     };
     let query = !strict ? searchIgboTextSearch(searchWord, isUsingMainKey) : strictSearchIgboQuery(searchWord);
     const words = await searchWordUsingIgbo({ query, ...searchQueries });
@@ -92,9 +93,14 @@ export const getWords = async (req, res, next) => {
 export const getWord = async (req, res, next) => {
   try {
     const { id } = req.params;
-    const { dialects } = handleQueries(req);
+    const { dialects, examples } = handleQueries(req);
 
-    const updatedWord = await findWordsWithMatch({ match: { _id: mongoose.Types.ObjectId(id) }, limit: 1, dialects })
+    const updatedWord = await findWordsWithMatch({
+      match: { _id: mongoose.Types.ObjectId(id) },
+      limit: 1,
+      dialects,
+      examples,
+    })
       .then(async ([word]) => {
         if (!word) {
           throw new Error('No word exists with the provided id.');

--- a/src/pages/components/Demo/Demo.js
+++ b/src/pages/components/Demo/Demo.js
@@ -59,6 +59,14 @@ const Demo = ({ searchWord, words }) => {
     }
   };
 
+  const handleExamples = ({ target }) => {
+    if (target.checked) {
+      setQueries({ ...queries, examples: target.checked });
+    } else {
+      setQueries(omit(queries, ['examples']));
+    }
+  };
+
   return !isLoading ? (
     <div className="flex justify-center mb-16">
       <div className="flex flex-col items-center md:items-start lg:flex-row lg:space-x-10">
@@ -90,6 +98,16 @@ const Demo = ({ searchWord, words }) => {
                 data-test="dialects-flag"
               >
                 Dialects
+              </Checkbox>
+            </div>
+            <div className="px-3 ">
+              <Checkbox
+                className="flex items-center space-x-2"
+                defaultChecked={initialQueries.examples}
+                onChange={handleExamples}
+                data-test="examples-flag"
+              >
+                Examples
               </Checkbox>
             </div>
             <button

--- a/swagger.json
+++ b/swagger.json
@@ -121,6 +121,13 @@
             "in": "query",
             "required": false,
             "type": "boolean"
+          },
+          {
+            "name": "examples",
+            "description": "Includes examples associated with returned document",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "responses": {

--- a/tests/api-mongo.test.js
+++ b/tests/api-mongo.test.js
@@ -141,6 +141,32 @@ describe('MongoDB Words', () => {
         });
     });
 
+    it('should return word information with examples query', (done) => {
+      const keyword = 'bia';
+      getWords({ keyword, examples: true })
+        .end((_, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body).to.have.lengthOf.at.least(2);
+          forEach(res.body, (word) => {
+            expect(word.examples).to.have.lengthOf.at.least(0);
+          });
+          done();
+        });
+    });
+
+    it('should return word information without examples with malformed examples query', (done) => {
+      const keyword = 'bia';
+      getWords({ keyword, examples: 'fdsafds' })
+        .end((_, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body).to.have.lengthOf.at.least(2);
+          forEach(res.body, (word) => {
+            expect(word.examples).to.equal(undefined);
+          });
+          done();
+        });
+    });
+
     it('should return word information with the filter query', (done) => {
       const filter = 'bia';
       getWords({ filter: { word: filter } })
@@ -380,7 +406,7 @@ describe('MongoDB Words', () => {
         expect(res.status).to.equal(200);
         expect(res.body).to.be.an('array');
         expect(res.body).to.have.lengthOf.at.most(10);
-        expect(res.body[0].word).to.equal(accents.remove('-mụ-mù'));
+        expect(res.body[0].word).to.equal('-mụ-mù');
         expect(some(res.body, (word) => isEqual(word.variations, ['-mu-mù']))).to.equal(true);
         done();
       });

--- a/tests/shared/constants.js
+++ b/tests/shared/constants.js
@@ -12,7 +12,6 @@ export const WORD_KEYS = [
   'variations',
   'definitions',
   'stems',
-  'examples',
   'id',
   'word',
   'wordClass',


### PR DESCRIPTION
## Background
Users were experiencing extremely long load times for requesting word documents that were at the end of the database (i.e. words that start with the letter 'w' would take a lot longer to be returned to the client compared to words starting with the letter 'a')

### Solution
Originally, all words would unconditionally look up their associated example documents. But this would increase the look-up time for more word document requests. This PR creates a new `example` query param that allows clients to specify whether or not they want to also request the associated example documents.

This significantly increases performance - I ran tests locally I noticed that the original ~8s request time for 10 words dropped down to 80ms 😱
