### PR TITLE
Expose Pronunciation Field

### DIFF
--- a/src/controllers/utils/buildDocs.js
+++ b/src/controllers/utils/buildDocs.js
@@ -81,6 +81,7 @@ export const findWordsWithMatch = async ({
       stems: 1,
       updatedOn: 1,
       accented: 1,
+      pronunciation: 1,
       ...(examples ? { examples: 1 } : {}),
       ...(dialects ? { dialects: 1 } : {}),
     })

--- a/src/models/Word.js
+++ b/src/models/Word.js
@@ -27,6 +27,7 @@ const wordSchema = new Schema({
       ));
     },
   },
+  pronunciation: { type: String, default: '' },
   isCentralIgbo: { type: Boolean, default: false },
   variations: { type: [{ type: String }], default: [] },
   normalized: { type: String, default: '' },

--- a/swagger.json
+++ b/swagger.json
@@ -36,6 +36,15 @@
             "type": "string"
           }
         },
+        "pronunciation": {
+          "type": "string"
+        },
+        "isCentralIgbo": {
+          "type": "string"
+        },
+        "accented": {
+          "type": "string"
+        },
         "variations": {
           "type": "array",
           "items": {

--- a/tests/shared/constants.js
+++ b/tests/shared/constants.js
@@ -15,6 +15,7 @@ export const WORD_KEYS = [
   'id',
   'word',
   'wordClass',
+  'pronunciation',
   'updatedOn',
 ];
 export const EXAMPLE_KEYS = ['accented', 'igbo', 'english', 'associatedWords', 'id', 'updatedOn'];


### PR DESCRIPTION
## Background
Each word document can have a pronunciation audio file associated with it. This PR exposes the `pronunciation` field that can contain an AWS S3 Bucket object URI that points to the audio pronunciation file.

This PR also:
* Updates the Swagger docs to better represents the shape of the Word schema