### PR TITLE
fix: remove normalized field on word documents

### DIFF
--- a/migrations/20210426171953-remove-normalized-field.js
+++ b/migrations/20210426171953-remove-normalized-field.js
@@ -1,0 +1,19 @@
+module.exports = {
+  async up(db) {
+    const collections = ['words'];
+    return collections.map((collection) => (
+      db.collection(collection).updateMany({}, {
+        $unset: { normalized: null },
+      })
+    ));
+  },
+
+  async down(db) {
+    const collections = ['words'];
+    return collections.map((collection) => (
+      db.collection(collection).updateMany({}, {
+        $set: { normalized: '' },
+      })
+    ));
+  },
+};

--- a/src/models/Word.js
+++ b/src/models/Word.js
@@ -30,7 +30,6 @@ const wordSchema = new Schema({
   pronunciation: { type: String, default: '' },
   isCentralIgbo: { type: Boolean, default: false },
   variations: { type: [{ type: String }], default: [] },
-  normalized: { type: String, default: '' },
   frequency: { type: Number },
   stems: { type: [{ type: String }], default: [] },
   accented: { type: String, default: '' },


### PR DESCRIPTION
## Background
Word documents no longer need the `normalized` field, so this PR removes it.

Closes #354 