### PR TITLE
Search for Words by Dialects

### DIFF
--- a/src/dictionaries/seed.js
+++ b/src/dictionaries/seed.js
@@ -3,6 +3,7 @@ import { map, flatten, keys } from 'lodash';
 import { createWord } from '../controllers/words';
 import dictionary from './ig-en/ig-en.json';
 import { MONGO_URI } from '../config';
+import Dialects from '../shared/constants/Dialects';
 
 const WRITE_DB_DELAY = 15000;
 
@@ -17,6 +18,16 @@ const populate = async () => {
         return map(value, (term) => {
           const word = { ...term };
           word.word = key;
+          word.dialects = Object.keys(Dialects).reduce((dialectsObject, dialectKey) => ({
+            ...dialectsObject,
+            [dialectKey]: {
+              word: `${key}-${dialectKey}`,
+              variations: [],
+              accented: '',
+              dialect: dialectKey,
+              pronunciation: '',
+            },
+          }), {});
           return createWord(word);
         });
       }),

--- a/src/models/Word.js
+++ b/src/models/Word.js
@@ -36,7 +36,13 @@ const wordSchema = new Schema({
   updatedOn: { type: Date, default: Date.now() },
 }, { toObject: toObjectPlugin });
 
-wordSchema.index({ word: 'text', variations: 'text' });
+/* Create text indexes for each dialect word field */
+const dialectsIndexFields = Object.keys(Dialects)
+  .reduce((indexFields, key) => (
+    { ...indexFields, [`dialects.${key}.word`]: 'text' }
+  ), {});
+
+wordSchema.index({ word: 'text', variations: 'text', ...dialectsIndexFields });
 
 toJSONPlugin(wordSchema);
 updatedOnHook(wordSchema);

--- a/tests/api-mongo.test.js
+++ b/tests/api-mongo.test.js
@@ -590,5 +590,18 @@ describe('MongoDB Words', () => {
           done();
         });
     });
+
+    it('should return a word by searching with nested dialect word', (done) => {
+      const keyword = 'akwa-ONI';
+      getWords({ keyword, dialects: true })
+        .end((_, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body).to.have.lengthOf.at.least(1);
+          forEach(res.body, (word) => {
+            expect(word.dialects.ONI.word).to.equal(`${word.word}-ONI`);
+          });
+          done();
+        });
+    });
   });
 });


### PR DESCRIPTION
## Background
When a user searches for a word, the backend uses MongoDB text indexes to look at each Word document `word` and `variations` fields to see if they match the user's search query. This meant that users who would search for words in their own dialects wouldn't get as many results if the word in their dialect didn't exactly match the headword for a given document.

This PR extends the text indexes to look at all the nested dialect words. This means if a headword is `mmiri` but a nested dialect word is `mmili`, a user would be able to search with `mmili` and get the document with the headword `mmiri` as a result.

Closes #356 