### PR TITLE
Migrating database to have default dialects

### DIFF
--- a/migrations/20210814210437-pre-populate-dialects.js
+++ b/migrations/20210814210437-pre-populate-dialects.js
@@ -1,0 +1,55 @@
+const dialectKeys = [
+  'NSA',
+  'UMU',
+  'ANI',
+  'OKA',
+  'AFI',
+  'MBA',
+  'EGB',
+  'OHU',
+  'ORL',
+  'NGW',
+  'OWE',
+  'NSU',
+  'BON',
+  'OGU',
+  'ONI',
+  'ECH',
+  'UNW',
+];
+
+module.exports = {
+  async up(db) {
+    const collections = ['words', 'wordSuggestions'];
+    return collections.map((collection) => (
+      db.collection(collection).updateMany({}, [{
+        $set: dialectKeys.reduce((finalSet, dialectKey) => ({
+          ...finalSet,
+          [`dialects.${dialectKey}.word`]: {
+            $cond: {
+              if: { $eq: [`$dialects.${dialectKey}.word`, ''] },
+              then: '$accented',
+              else: `$dialects.${dialectKey}.accented`,
+            },
+          },
+          [`dialects.${dialectKey}.accented`]: {
+            $cond: {
+              if: { $eq: [`$dialects.${dialectKey}.accented`, ''] },
+              then: '$accented',
+              else: `$dialects.${dialectKey}.accented`,
+            },
+          },
+        }), {}),
+      }])
+    ));
+  },
+
+  async down(db) {
+    const collections = ['words', 'wordSuggestions'];
+    return collections.map((collection) => (
+      db.collection(collection).updateMany({}, [{
+        $set: { word: '$word' },
+      }])
+    ));
+  },
+};

--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -169,17 +169,20 @@ export const createWord = async (data) => {
     definitions,
     variations,
     stems,
+    accented,
     dialects,
+    ...rest
   } = data;
 
-  const emptyDialects = Object.keys(Dialects).reduce((dialectsObject, key) => ({
+  const filledDialects = Object.keys(Dialects).reduce((dialectsObject, key) => ({
     ...dialectsObject,
     [key]: {
-      word: '',
       variations: [],
-      accented: '',
       dialect: key,
       pronunciation: '',
+      ...dialects[key],
+      word: dialects[key].word || accented || word,
+      accented: dialects[key].accented || accented || word,
     },
   }), {});
 
@@ -189,10 +192,9 @@ export const createWord = async (data) => {
     definitions,
     variations,
     stems,
-    dialects: {
-      ...emptyDialects,
-      ...dialects,
-    },
+    accented: accented || word,
+    dialects: filledDialects,
+    ...rest,
   };
 
   const newWord = new Word(wordData);

--- a/src/dictionaries/seed.js
+++ b/src/dictionaries/seed.js
@@ -23,7 +23,7 @@ const populate = async () => {
             [dialectKey]: {
               word: `${key}-${dialectKey}`,
               variations: [],
-              accented: '',
+              accented: `${key}-${dialectKey}-accented`,
               dialect: dialectKey,
               pronunciation: '',
             },


### PR DESCRIPTION
## Background
All the default values for a given word's dialect's `word` and `accented` fields are empty. We want to have the default value for nested dialect fields `word` and `accented` to have the same initial value as the head word's `accented` or `word` field.

This PR introduces a migration that will set all the nested `word` and `accented` fields within the `dialects` field for any word to the word's `accented` or `word` value.