### PR TITLE
Remove `accented` field from Words and Examples

### DIFF
--- a/migrations/20210820170937-merge-accented-and-word.js
+++ b/migrations/20210820170937-merge-accented-and-word.js
@@ -1,0 +1,78 @@
+const dialectKeys = [
+  'NSA',
+  'UMU',
+  'ANI',
+  'OKA',
+  'AFI',
+  'MBA',
+  'EGB',
+  'OHU',
+  'ORL',
+  'NGW',
+  'OWE',
+  'NSU',
+  'BON',
+  'OGU',
+  'ONI',
+  'ECH',
+  'UNW',
+];
+
+module.exports = {
+  async up(db) {
+    const collections = ['words', 'wordSuggestions'];
+    const wordAccentedMigration = {
+      word: {
+        $cond: {
+          if: {
+            $and: [
+              { $ne: ['$accented', ''] },
+              { $ne: ['$accented', null] },
+              { $ne: ['$accented', undefined] },
+            ],
+          },
+          then: '$accented',
+          else: '$word',
+        },
+      },
+    };
+
+    const nestedDialectsWordAccentedMigration = dialectKeys.reduce((finalSet, dialectKey) => ({
+      ...finalSet,
+      [`dialects.${dialectKey}.word`]: {
+        $cond: {
+          if: {
+            $and: [
+              { $ne: [`$dialects.${dialectKey}.accented`, ''] },
+              { $ne: [`$dialects.${dialectKey}.accented`, null] },
+              { $ne: [`$dialects.${dialectKey}.accented`, undefined] },
+            ],
+          },
+          then: `$dialects.${dialectKey}.accented`,
+          else: '$accented',
+        },
+      },
+    }), {});
+
+    return collections.map((collection) => (
+      db.collection(collection).updateMany({}, [{
+        $set: {
+          ...wordAccentedMigration,
+          ...nestedDialectsWordAccentedMigration,
+        },
+      },
+      {
+        $unset: ['accented'].concat(dialectKeys.map((dialectKey) => `dialects.${dialectKey}.accented`)),
+      }])
+    ));
+  },
+
+  async down(db) {
+    const collections = ['words', 'wordSuggestions'];
+    return collections.map((collection) => (
+      db.collection(collection).updateMany({}, [{
+        $set: { word: '$word', accented: '$word' },
+      }])
+    ));
+  },
+};

--- a/migrations/20210820175620-merge-accented-and-example.js
+++ b/migrations/20210820175620-merge-accented-and-example.js
@@ -1,0 +1,40 @@
+module.exports = {
+  async up(db) {
+    const collections = ['examples', 'exampleSuggestions'];
+    const igboAccentedMigration = {
+      igbo: {
+        $cond: {
+          if: {
+            $and: [
+              { $ne: ['$accented', ''] },
+              { $ne: ['$accented', null] },
+              { $ne: ['$accented', undefined] },
+            ],
+          },
+          then: '$accented',
+          else: '$igbo',
+        },
+      },
+    };
+
+    return collections.map((collection) => (
+      db.collection(collection).updateMany({}, [{
+        $set: {
+          ...igboAccentedMigration,
+        },
+      },
+      {
+        $unset: ['accented'],
+      }])
+    ));
+  },
+
+  async down(db) {
+    const collections = ['examples', 'exampleSuggestions'];
+    return collections.map((collection) => (
+      db.collection(collection).updateMany({}, [{
+        $set: { igbo: '$igbo', accented: '$igbo' },
+      }])
+    ));
+  },
+};

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "react-json-pretty": "^2.2.0",
     "react-reveal": "^1.2.2",
     "react-scroll": "^1.8.1",
-    "remove-accents": "^0.4.2",
     "rimraf": "^3.0.2",
     "shelljs": "^0.8.4",
     "string-similarity": "^4.0.2",

--- a/src/controllers/utils/buildDocs.js
+++ b/src/controllers/utils/buildDocs.js
@@ -2,7 +2,6 @@
 /* eslint-disable no-underscore-dangle */
 
 import { assign, map, forEach } from 'lodash';
-import accents from 'remove-accents';
 import Word from '../../models/Word';
 
 /**
@@ -11,14 +10,8 @@ import Word from '../../models/Word';
  */
 const removeKeysInNestedDoc = (docs, nestedDocsKey) => {
   forEach(docs, (doc) => {
-    // Handles removing accent marks for word
-    doc.word = accents.remove(doc.word);
     doc[nestedDocsKey] = map(doc[nestedDocsKey], (nestedDoc) => {
       const updatedNestedDoc = assign(nestedDoc, { id: nestedDoc._id });
-      if (nestedDocsKey === 'examples') {
-        // Handles remove accent marks for example's igbo
-        updatedNestedDoc.igbo = accents.remove(updatedNestedDoc.igbo);
-      }
       delete updatedNestedDoc._id;
       delete updatedNestedDoc.__v;
       return updatedNestedDoc;
@@ -80,7 +73,6 @@ export const findWordsWithMatch = async ({
       variations: 1,
       stems: 1,
       updatedOn: 1,
-      accented: 1,
       pronunciation: 1,
       isCentralIgbo: 1,
       ...(examples ? { examples: 1 } : {}),

--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -169,7 +169,6 @@ export const createWord = async (data) => {
     definitions,
     variations,
     stems,
-    accented,
     dialects,
     ...rest
   } = data;
@@ -181,8 +180,7 @@ export const createWord = async (data) => {
       dialect: key,
       pronunciation: '',
       ...dialects[key],
-      word: dialects[key].word || accented || word,
-      accented: dialects[key].accented || accented || word,
+      word: dialects[key].word || word,
     },
   }), {});
 
@@ -192,7 +190,6 @@ export const createWord = async (data) => {
     definitions,
     variations,
     stems,
-    accented: accented || word,
     dialects: filledDialects,
     ...rest,
   };

--- a/src/dictionaries/seed.js
+++ b/src/dictionaries/seed.js
@@ -23,7 +23,6 @@ const populate = async () => {
             [dialectKey]: {
               word: `${key}-${dialectKey}`,
               variations: [],
-              accented: `${key}-${dialectKey}-accented`,
               dialect: dialectKey,
               pronunciation: '',
             },

--- a/src/models/Example.js
+++ b/src/models/Example.js
@@ -1,22 +1,15 @@
 import mongoose from 'mongoose';
-import {
-  toJSONPlugin,
-  toObjectPlugin,
-  updatedOnHook,
-  normalizeExampleHook,
-} from './plugins';
+import { toJSONPlugin, toObjectPlugin, updatedOnHook } from './plugins';
 
 const { Schema, Types } = mongoose;
 const exampleSchema = new Schema({
   igbo: { type: String, default: '' },
   english: { type: String, default: '' },
   associatedWords: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
-  accented: { type: String, default: '' },
   updatedOn: { type: Date, default: Date.now() },
 }, { toObject: toObjectPlugin });
 
 toJSONPlugin(exampleSchema);
 updatedOnHook(exampleSchema);
-normalizeExampleHook(exampleSchema);
 
 export default mongoose.model('Example', exampleSchema);

--- a/src/models/Word.js
+++ b/src/models/Word.js
@@ -1,14 +1,9 @@
 import mongoose from 'mongoose';
 import { every, has, partial } from 'lodash';
-import {
-  normalizeWordHook,
-  toJSONPlugin,
-  toObjectPlugin,
-  updatedOnHook,
-} from './plugins';
+import { toJSONPlugin, toObjectPlugin, updatedOnHook } from './plugins';
 import Dialects from '../shared/constants/Dialects';
 
-const REQUIRED_DIALECT_KEYS = ['word', 'variations', 'accented', 'dialect', 'pronunciation'];
+const REQUIRED_DIALECT_KEYS = ['word', 'variations', 'dialect', 'pronunciation'];
 const REQUIRED_DIALECT_CONSTANT_KEYS = ['code', 'value', 'label'];
 
 const { Schema } = mongoose;
@@ -32,7 +27,6 @@ const wordSchema = new Schema({
   variations: { type: [{ type: String }], default: [] },
   frequency: { type: Number },
   stems: { type: [{ type: String }], default: [] },
-  accented: { type: String, default: '' },
   updatedOn: { type: Date, default: Date.now() },
 }, { toObject: toObjectPlugin });
 
@@ -46,7 +40,6 @@ wordSchema.index({ word: 'text', variations: 'text', ...dialectsIndexFields });
 
 toJSONPlugin(wordSchema);
 updatedOnHook(wordSchema);
-normalizeWordHook(wordSchema);
 
 const WordModel = mongoose.model('Word', wordSchema);
 WordModel.syncIndexes();

--- a/src/models/plugins/index.js
+++ b/src/models/plugins/index.js
@@ -2,9 +2,7 @@
 /* Code from https://stackoverflow.com/q/30431262 */
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable no-param-reassign */
-import { map } from 'lodash';
 import mongoose from 'mongoose';
-import accents from 'remove-accents';
 
 /* Replaces the _id key with id */
 export const toJSONPlugin = (schema) => {
@@ -36,33 +34,3 @@ export const updatedOnHook = (schema) => (
     return this;
   })
 );
-
-/* Removes accent marks found in the word field before sending to client */
-export const normalizeWordHook = (schema) => {
-  schema.post('find', (docs) => (
-    map(docs, (doc) => {
-      doc.word = accents.remove(doc.word);
-      return doc;
-    })
-  ));
-  schema.post('findOne', (doc) => {
-    doc.word = accents.remove(doc.word);
-    return doc;
-  });
-};
-
-/* Removes accent marks found in the igbo text before sending to client */
-export const normalizeExampleHook = (schema) => {
-  schema.post('find', (docs) => (
-    map(docs, (doc) => {
-      doc.igbo = accents.remove(doc.igbo);
-      return doc;
-    })
-  ));
-  schema.post('findOne', (doc) => {
-    if (doc) {
-      doc.igbo = accents.remove(doc?.igbo || '');
-    }
-    return doc;
-  });
-};

--- a/swagger.json
+++ b/swagger.json
@@ -42,9 +42,6 @@
         "isCentralIgbo": {
           "type": "string"
         },
-        "accented": {
-          "type": "string"
-        },
         "variations": {
           "type": "array",
           "items": {

--- a/tests/api-mongo.test.js
+++ b/tests/api-mongo.test.js
@@ -9,7 +9,6 @@ import {
 } from 'lodash';
 import stringSimilarity from 'string-similarity';
 import diacriticless from 'diacriticless';
-import accents from 'remove-accents';
 import Word from '../src/models/Word';
 import {
   WORD_KEYS,
@@ -40,7 +39,6 @@ describe('MongoDB Words', () => {
           [key]: {
             word: '',
             variations: [],
-            accented: '',
             dialect: key,
             pronunciation: '',
           },
@@ -69,7 +67,6 @@ describe('MongoDB Words', () => {
           [key]: {
             word: '',
             variations: [],
-            accented: '',
             dialect: 'mismatch',
             pronunciation: '',
           },
@@ -550,13 +547,12 @@ describe('MongoDB Words', () => {
         });
     });
 
-    it('should return accented field and normalized word', (done) => {
+    it('should return accented word', (done) => {
       getWords()
         .end((_, res) => {
           expect(res.status).to.equal(200);
           forEach(res.body, (word) => {
-            expect(word.word).to.equal(accents.remove(word.word));
-            expect(word.accented).to.not.equal(undefined);
+            expect(word.word).to.not.equal(undefined);
           });
           done();
         });

--- a/tests/examples.test.js
+++ b/tests/examples.test.js
@@ -1,6 +1,5 @@
 import chai from 'chai';
 import { isEqual, forEach } from 'lodash';
-import accents from 'remove-accents';
 import SortingDirections from '../src/shared/constants/sortingDirections';
 import { getExamples, getExample } from './shared/commands';
 import {
@@ -160,25 +159,23 @@ describe('MongoDB Examples', () => {
         });
     });
 
-    it('should return accented field with keyword', (done) => {
+    it('should return accented keyword', (done) => {
       const keyword = 'Òbìàgèlì bì n’Àba';
       getExamples({ keyword })
         .end((_, res) => {
           expect(res.status).to.equal(200);
           forEach(res.body, (example) => {
-            expect(example.igbo).to.equal(accents.remove(keyword));
             expect(example.igbo).to.not.equal(undefined);
           });
           done();
         });
     });
 
-    it('should return accented field and normalized example', (done) => {
+    it('should return accented example', (done) => {
       getExamples()
         .end((_, res) => {
           expect(res.status).to.equal(200);
           forEach(res.body, (example) => {
-            expect(example.igbo).to.equal(accents.remove(example.igbo));
             expect(example.igbo).to.not.equal(undefined);
           });
           done();

--- a/tests/shared/constants.js
+++ b/tests/shared/constants.js
@@ -8,7 +8,6 @@ export const API_URL = 'https://igboapi.com';
 export const SAVE_DOC_DELAY = 2000;
 
 export const WORD_KEYS = [
-  'accented',
   'variations',
   'definitions',
   'stems',
@@ -19,7 +18,7 @@ export const WORD_KEYS = [
   'isCentralIgbo',
   'updatedOn',
 ];
-export const EXAMPLE_KEYS = ['accented', 'igbo', 'english', 'associatedWords', 'id', 'updatedOn'];
+export const EXAMPLE_KEYS = ['igbo', 'english', 'associatedWords', 'id', 'updatedOn'];
 export const DIALECT_KEYS = [
   'NSA',
   'UMU',

--- a/yarn.lock
+++ b/yarn.lock
@@ -11248,11 +11248,6 @@ regjsparser@^0.6.4:
   dependencies:
     jsesc "~0.5.0"
 
-remove-accents@^0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
-  integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
-
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"


### PR DESCRIPTION
## Background
The `accented` field is no longer necessary since the `word` can handle diacritics. This PR removes the `accented` field and overwrites all `word` fields with the original `accented` field data.

This PR also:
* Remove the `remove-accents` npm package