### PR TITLE
feat: change Central Igbo to Central Igbo

### DIFF
--- a/migrations/20210822145619-change-central-to-standard.js
+++ b/migrations/20210822145619-change-central-to-standard.js
@@ -1,0 +1,25 @@
+module.exports = {
+  async up(db) {
+    const collections = ['words', 'wordsuggestions'];
+    return collections.map((collection) => (
+      db.collection(collection).updateMany({}, [{
+        $set: { isStandardIgbo: '$isCentralIgbo' },
+      },
+      {
+        $unset: 'isCentralIgbo',
+      }])
+    ));
+  },
+
+  async down(db) {
+    const collections = ['words', 'wordsuggestions'];
+    return collections.map((collection) => (
+      db.collection(collection).updateMany({}, [{
+        $set: { isCentralIgbo: '$isStandardIgbo' },
+      },
+      {
+        $unset: 'isStandardIgbo',
+      }])
+    ));
+  },
+};

--- a/src/controllers/utils/buildDocs.js
+++ b/src/controllers/utils/buildDocs.js
@@ -74,7 +74,7 @@ export const findWordsWithMatch = async ({
       stems: 1,
       updatedOn: 1,
       pronunciation: 1,
-      isCentralIgbo: 1,
+      isStandardIgbo: 1,
       ...(examples ? { examples: 1 } : {}),
       ...(dialects ? { dialects: 1 } : {}),
     })

--- a/src/models/Word.js
+++ b/src/models/Word.js
@@ -23,7 +23,7 @@ const wordSchema = new Schema({
     },
   },
   pronunciation: { type: String, default: '' },
-  isCentralIgbo: { type: Boolean, default: false },
+  isStandardIgbo: { type: Boolean, default: false },
   variations: { type: [{ type: String }], default: [] },
   frequency: { type: Number },
   stems: { type: [{ type: String }], default: [] },

--- a/swagger.json
+++ b/swagger.json
@@ -39,7 +39,7 @@
         "pronunciation": {
           "type": "string"
         },
-        "isCentralIgbo": {
+        "isStandardIgbo": {
           "type": "string"
         },
         "variations": {

--- a/tests/shared/constants.js
+++ b/tests/shared/constants.js
@@ -15,7 +15,7 @@ export const WORD_KEYS = [
   'word',
   'wordClass',
   'pronunciation',
-  'isCentralIgbo',
+  'isStandardIgbo',
   'updatedOn',
 ];
 export const EXAMPLE_KEYS = ['igbo', 'english', 'associatedWords', 'id', 'updatedOn'];


### PR DESCRIPTION
## Background
To better represent the type of data that's being stored in our database we want to change the `isCentralIgbo` field to `isStandardIgbo`.

Closes #390 