### PR TITLE
feat: add isComplete to word model

### DIFF
--- a/migrations/20210831163032-add-is-complete-word.js
+++ b/migrations/20210831163032-add-is-complete-word.js
@@ -1,0 +1,19 @@
+module.exports = {
+  async up(db) {
+    const collections = ['words', 'wordsuggestions'];
+    return collections.map((collection) => (
+      db.collection(collection).updateMany({}, [{
+        $set: { isComplete: false },
+      }])
+    ));
+  },
+
+  async down(db) {
+    const collections = ['words', 'wordsuggestions'];
+    return collections.map((collection) => (
+      db.collection(collection).updateMany({}, [{
+        $unset: 'isComplete',
+      }])
+    ));
+  },
+};

--- a/src/models/Word.js
+++ b/src/models/Word.js
@@ -24,6 +24,7 @@ const wordSchema = new Schema({
   },
   pronunciation: { type: String, default: '' },
   isStandardIgbo: { type: Boolean, default: false },
+  isComplete: { type: Boolean, default: false },
   variations: { type: [{ type: String }], default: [] },
   frequency: { type: Number },
   stems: { type: [{ type: String }], default: [] },


### PR DESCRIPTION
## Background
To better track the status and quality of words within the database, we will add the hidden `isComplete` field on the Word model. This field will only be used within the Igbo API Editor Platform, so we want to make sure our public schema can handle this new field.