### PR TITLE
chore(homepage): change github icon color and central to standard igbo

### DIFF
--- a/src/pages/App.js
+++ b/src/pages/App.js
@@ -50,7 +50,7 @@ const App = ({ searchWord, words }) => {
                   style={{ minWidth: '18rem' }}
                 >
                   Check on GitHub
-                  <i className="fa fa-github text-3xl pl-3 text-black" />
+                  <i className="fa fa-github text-3xl pl-3" />
                 </button>
                 <button
                   type="button"

--- a/src/pages/components/Statistics/Statistics.js
+++ b/src/pages/components/Statistics/Statistics.js
@@ -21,7 +21,7 @@ const Statistics = () => {
         <Stat value="8,000" header="Words in the database" />
         <Stat value="2,000" header="Example Igbo sentences" />
         <Stat value="1,400" header="Word audio pronunciations" />
-        <Stat value="500" header="Central Igbo words" />
+        <Stat value="500" header="Standard Igbo words" />
       </div>
       <div className="flex flex-col lg:flex-row flex-wrap justify-center items-center bg-gray-200 py-6">
         {contributorDetails ? (

--- a/tests/cypress/integration/client.test.js
+++ b/tests/cypress/integration/client.test.js
@@ -78,7 +78,7 @@ describe('Igbo API Homepage', () => {
     });
     it('render the Sign up page', () => {
       cy.findByAltText('down arrow as menu icon').click();
-      cy.get('a').contains('Get an API Key').click();
+      cy.get('button').contains('Get an API Key').click();
       cy.findByText('Sign up.');
     });
   });


### PR DESCRIPTION
## Background
Change the GitHub icon color to match the hover and non-hover states of the button text.
Change Central Igbo to Standard Igbo

## Demo
<img width="336" alt="Screen Shot 2021-11-21 at 9 28 08 AM" src="https://user-images.githubusercontent.com/16169291/142772608-bb61cb61-1e70-4898-9ebb-ce2f870d89f1.png">
<img width="332" alt="Screen Shot 2021-11-21 at 9 28 02 AM" src="https://user-images.githubusercontent.com/16169291/142772610-50299e07-ed36-402f-82e3-401ac0ac8e08.png">
