### PR TITLE
chore: change json theme to work on dark backgrounds

### DIFF
--- a/src/pages/components/Demo/Demo.js
+++ b/src/pages/components/Demo/Demo.js
@@ -123,7 +123,7 @@ const Demo = ({ searchWord, words }) => {
             Response
           </h3>
           <JSONPretty
-            className="w-full self-center lg:w-auto jsonPretty bg-gray-800 rounded-md p-2"
+            className="jsonPretty w-full self-center lg:w-auto bg-gray-800 rounded-md p-2"
             id="json-pretty"
             data={responseBody}
           />

--- a/src/pages/styles.less
+++ b/src/pages/styles.less
@@ -93,14 +93,14 @@
   max-width: 95vw;
   overflow: scroll;
   font-size: 1em;
-  @apply text-white;
+  color: rgb(153, 218, 255);
 }
 
 .__json-key__ {
-  color: black;
+  color: rgb(184, 245, 209);
 }
 .__json-string__ {
-  color: rgb(0, 77, 15);
+  color: rgb(255, 255, 255);
 }
 
 .demo-inputs-container {


### PR DESCRIPTION
## Issue
Closes #411 

## Background
Updates the JSON color theme to work better on the dark background.

## After
<img width="639" alt="Screen Shot 2021-11-24 at 8 57 30 AM" src="https://user-images.githubusercontent.com/16169291/143282227-0b7b491a-435a-465a-83dc-6962d818eca0.png">

## Before
<img width="639" alt="Screen Shot 2021-11-24 at 8 57 36 AM" src="https://user-images.githubusercontent.com/16169291/143282219-927c56fe-6e81-45d8-81e7-d9960aa7b207.png">