### PR TITLE
fix(site): use HTML img to render GitHub contributors

### DIFF
--- a/src/pages/components/Statistics/Statistics.js
+++ b/src/pages/components/Statistics/Statistics.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Image from 'next/image';
 import Stat from './Stat';
 
 const Statistics = ({
@@ -24,9 +23,9 @@ const Statistics = ({
           <div className="flex flex-row flex-wrap justify-center items-center">
             {contributors.slice(0, 10).map((contributor) => (
               <div key={contributor.avatar_url}>
-                <Image
+                <img
                   src={contributor.avatar_url}
-                  className=" text-gray-700 bg-gray-400  w-12  m-2 rounded-full"
+                  className=" text-gray-700 bg-gray-400 w-12  m-2 rounded-full"
                   alt="github avatar"
                 />
               </div>


### PR DESCRIPTION
## Background
This PR uses the regular `img` element instead of Next.js' `Image` component to render remotely hosted images of GitHub contributors