### PR TITLE
fix(site): make the dictionary link clickable on mobile

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,7 @@
 {
   "baseUrl": "http://localhost:8080",
   "video": false,
+  "chromeWebSecurity": false,
   "execTimeout": 5000,
   "retries": {
     "runMode": 2

--- a/src/pages/components/Demo/Demo.js
+++ b/src/pages/components/Demo/Demo.js
@@ -124,10 +124,10 @@ const Demo = ({ searchWord, words }) => {
             </p>
           </form>
         </div>
-        <div className="flex flex-col w-full lg:w-auto -mt-32">
+        <div className="flex flex-col w-full lg:w-auto lg:-mt-24">
           <h3
-            className="text-center lg:text-left self-center w-full font-bold
-          lg:w-auto lg:self-start text-2xl mb-5 mt-28 lg:mt-0 text-white lg:text-gray-800"
+            className="text-center lg:text-left self-center w-full font-bold lg:mt-4
+          lg:w-auto lg:self-start text-2xl mb-5text-white lg:text-gray-800"
           >
             Response
           </h3>

--- a/tests/cypress/integration/client.test.js
+++ b/tests/cypress/integration/client.test.js
@@ -91,5 +91,10 @@ describe('Igbo API Homepage', () => {
       cy.get('button').contains('Get an API Key').click();
       cy.findByText('Sign up.');
     });
+
+    it('navigate to Nkọwa okwu', () => {
+      cy.visit('/');
+      cy.get('.demo-inputs-container').contains('Nkọwa okwu').click();
+    });
   });
 });


### PR DESCRIPTION
## Background
The Nkọwa okwu link in the demo section wasn't clickable on mobile. There was another element that was sitting on top of the link.

## Solution
Move the element below the link.

## Report
https://twitter.com/codeshifu/status/1470305475560419328?s=20