### PR TITLE
feat(iscomplete): add the isComplete field to better track word completion

### DIFF
--- a/migrations/20211218192401-add-isComplete.js
+++ b/migrations/20211218192401-add-isComplete.js
@@ -1,0 +1,74 @@
+/* eslint-disable max-len */
+const wordsPipeline = [
+  {
+    $lookup: {
+      from: 'examples',
+      localField: '_id',
+      foreignField: 'associatedWords',
+      as: 'examples',
+    },
+  },
+  {
+    $addFields: {
+      isComplete: {
+        $function: {
+          body: `function(word, wordClass, definitions = [], examples = [], pronunciation, isStandardIgbo) {
+            var accentArray = ['á','à','ã','â','é','è','ê','í','ì','î','õ','ó','ò','ô','ú','ù','û','ị̀','ị́','ị̄','ọ́','ọ̀','ọ̄']
+            var hasAccent = false;
+            for(var i=0; i < word.length; i++){
+              if (hasAccent) { break; }
+                for(var j=0; j < accentArray.length; j++){
+                  if (hasAccent) { break; } 
+                    if(word[i] === accentArray[j]){
+                      hasAccent = true;
+                    }
+                }
+            }
+            return !!(word
+            && (hasAccent || word.match(/(?!\u0323)[\u0300-\u036f]/g))
+            && wordClass
+            && definitions.length
+            && examples.length
+            && pronunciation.length > 10
+            && isStandardIgbo
+            )
+          }`,
+          args: [
+            '$word',
+            '$wordClass',
+            '$definitions',
+            '$examples',
+            '$pronunciation',
+            '$isStandardIgbo',
+          ],
+          lang: 'js',
+        },
+      },
+    },
+  },
+];
+
+module.exports = {
+  async up(db) {
+    const collections = ['words', 'wordsuggestions'];
+    await Promise.all(collections.map(async (collection) => {
+      const wordDocs = await (await db.collection(collection).aggregate(wordsPipeline)).toArray();
+      await Promise.all(wordDocs.map((wordDoc) => (
+        db.collection(collection).updateOne(
+          // eslint-disable-next-line
+          { _id: wordDoc._id },
+          { $set: { isComplete: wordDoc.isComplete } },
+        )
+      )));
+    }));
+  },
+
+  async down(db) {
+    const collections = ['words', 'wordsuggestions'];
+    return collections.map((collection) => (
+      db.collection(collection).updateMany({}, [{
+        $unset: 'isComplete',
+      }])
+    ));
+  },
+};

--- a/src/models/Word.js
+++ b/src/models/Word.js
@@ -36,6 +36,7 @@ const wordSchema = new Schema({
   hypernyms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
   hyponyms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
   stems: { type: [{ type: String }], default: [] },
+  isComplete: { type: Boolean, default: false },
   updatedOn: { type: Date, default: Date.now() },
 }, { toObject: toObjectPlugin });
 


### PR DESCRIPTION
## Background
Certain Igbo words will not have tone markings since we have taken the stance of not marking high tones to decrease the tedious nature of editing for translators. To better keep mark when words are fully complete, there is the new `isComplete` field.
