### PR TITLE
Avoid Throwing Developer Account Creation Error

### DIFF
--- a/.github/workflows/audio_backup.yml
+++ b/.github/workflows/audio_backup.yml
@@ -5,9 +5,6 @@ on:
     # Backs up AWS audio pronunciations every Sunday at 12:00 AM UTC
     - cron: '0 0 * * 0'
 
-on:
-  push
-
 env:
   AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/dockerize.yml
+++ b/.github/workflows/dockerize.yml
@@ -10,17 +10,13 @@ jobs:
     name: Dockerize
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [16.x]
-
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
-      - name: Use Node.js @${{ matrix.node-version }}
+      - name: Use Node.js @16
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 16
       - name: Log into Docker Account
         run: echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
         env:

--- a/src/controllers/developers.js
+++ b/src/controllers/developers.js
@@ -38,12 +38,10 @@ export const postDeveloper = async (req, res, next) => {
     });
     await developer.save();
     if (process.env.NODE_ENV !== 'test') {
-      // eslint-disable-next-line
       try {
         await sendNewDeveloper({ to: email, apiKey, name });
       } catch (err) {
         console.log(err.response.body.errors);
-        throw err.response.body.errors;
       }
     }
     return res.send({


### PR DESCRIPTION
## Background
Our SendGrid API token was invalidated, which was throwing an error. But by throwing the error, the successfully created developer token was unable to be sent back to the frontend. This PR catches SendGrid related errors and console logs the message instead of sending back a 400 status code.

This PR also updates a few syntax errors with our CI pipelines.