### PR TITLE
chore(docker): upgrade docker node version from 12 to 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:16
 
 WORKDIR /app
 


### PR DESCRIPTION
## Background
The Dockerize action was failing due to using node version 12. This updates the node version to use 16.