### PR TITLE
fix(analytics): pass in the next public ga id during build time

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "shx rm -rf build/ && yarn build:src && cross-env NODE_ENV=build yarn build:dictionaries && yarn build:site",
     "build:src": "./node_modules/.bin/babel -d build/ ./src -s",
     "build:dictionaries": "babel-node src/dictionaries/buildDictionaries.js",
-    "build:site": "next build && yarn build:fonts && yarn build:assets",
+    "build:site": "NEXT_PUBLIC_GA_ID=$NEXT_PUBLIC_GA_ID next build && yarn build:fonts && yarn build:assets",
     "build:fonts": "shx cp -r ./src/public/fonts/ ./build/dist/fonts",
     "build:assets": "shx cp -r ./src/pages/assets/ ./build/dist/assets",
     "clean": "shx rm -rf node_modules/ build/ out/ yarn.lock package-lock.json *.log",


### PR DESCRIPTION
## Background
Passing in the `NEXT_PUBLIC_GA_ID` environment variable at build time