### PR TITLE
fix: remove prefixed hyphens from words

### DIFF
--- a/migrations/20220216030851-remove-verb-prefixes.js
+++ b/migrations/20220216030851-remove-verb-prefixes.js
@@ -1,0 +1,76 @@
+const wordsMigrationPipeline = [
+  {
+    $match: {
+      word: {
+        $regex: '^-',
+        $options: 'i',
+      },
+      wordClass: {
+        $in: ['AV', 'PV', 'MV'],
+      },
+    },
+  }, {
+    $set: {
+      word: {
+        $function: {
+          // eslint-disable-next-line
+          body: 'function(word) { let updatedWord = word; if (word.startsWith(\'-\')) { updatedWord = word.substring(1); } return updatedWord; }', 
+          args: ['$word'],
+          lang: 'js',
+        },
+      },
+    },
+  },
+];
+
+const wordsRevertPipeline = [
+  {
+    $match: {
+      wordClass: {
+        $in: ['AV', 'PV', 'MV'],
+      },
+    },
+  }, {
+    $set: {
+      word: {
+        $function: {
+          body: 'function(word) { if (!word.startsWith(\'-\')) { return \'-\' + word; } return word; }',
+          args: ['$word'],
+          lang: 'js',
+        },
+      },
+    },
+  },
+];
+
+module.exports = {
+  async up(db) {
+    const collections = ['words', 'wordsuggestions'];
+    await Promise.all(
+      collections.map(async (collection) => {
+        const wordDocs = await (await db.collection(collection).aggregate(wordsMigrationPipeline)).toArray();
+        await Promise.all(wordDocs.map((wordDoc) => (
+          db.collection(collection).updateOne(
+            // eslint-disable-next-line
+            { _id: wordDoc._id },
+            { $set: { word: wordDoc.word } },
+          )
+        )));
+      }));
+  },
+
+  async down(db) {
+    const collections = ['words', 'wordsuggestions'];
+    await Promise.all(
+      collections.map(async (collection) => {
+        const wordDocs = await (await db.collection(collection).aggregate(wordsRevertPipeline)).toArray();
+        await Promise.all(wordDocs.map((wordDoc) => (
+          db.collection(collection).updateOne(
+            // eslint-disable-next-line
+            { _id: wordDoc._id },
+            { $set: { word: wordDoc.word } },
+          )
+        )));
+      }));
+  },
+};


### PR DESCRIPTION
## Background
To match the lexicographic standard of cataloging Igbo verbs, the Igbo API will migrate its data so that verbs don't include a prefixed hyphen.