### PR TITLE
fix(site): make demo response scrollable

### DIFF
--- a/src/pages/components/Demo/Demo.js
+++ b/src/pages/components/Demo/Demo.js
@@ -134,7 +134,7 @@ const Demo = ({ searchWord, words }) => {
             {t('Response')}
           </h3>
           <JSONPretty
-            className="jsonPretty w-full self-center lg:w-auto bg-gray-800 rounded-md p-2"
+            className="jsonPretty w-full self-center lg:w-auto bg-gray-800 rounded-md p-2 overflow-auto"
             id="json-pretty"
             data={responseBody}
           />


### PR DESCRIPTION


https://user-images.githubusercontent.com/48206628/156936568-ee3d57f0-776c-46ef-8c30-74f7584b3eda.mp4

https://i.imgur.com/mXBpTdE.png

in chrome this is seemingly set automatically, but in firefox we have to explicitly state it, using tailwinds `overflow-auto`