### PR TITLE
fix(timestamps): change updatedOn to updatedAt and using ISO format

### DIFF
--- a/migrations/20220301211505-convert-unix-to-iso.js
+++ b/migrations/20220301211505-convert-unix-to-iso.js
@@ -1,0 +1,79 @@
+const updatedOnConversion = [
+  {
+    $set: {
+      updatedAt: {
+        $function: {
+          body: `function(updatedOn, updatedAt) {
+            if (updatedOn) {
+              return new Date(updatedOn).toISOString();
+            }
+            return updatedAt || updatedOn;
+          }`,
+          args: [
+            '$updatedOn',
+            '$updatedAt',
+          ],
+          lang: 'js',
+        },
+      },
+    },
+  }, {
+    $unset: 'updatedOn',
+  },
+];
+
+const updatedOnRevert = [
+  {
+    $set: {
+      updatedOn: {
+        $function: {
+          body: 'function(updatedAt) { return new Date(updatedAt).valueOf(); }',
+          args: [
+            '$updatedAt',
+          ],
+          lang: 'js',
+        },
+      },
+    },
+  }, {
+    $unset: 'updatedAt',
+  },
+];
+
+module.exports = {
+  async up(db) {
+    const collections = ['words', 'examples', 'wordsuggestions', 'examplesuggestions', 'genericwords'];
+    await Promise.all(
+      collections.map(async (collection) => {
+        const docs = await (await db.collection(collection).aggregate(updatedOnConversion)).toArray();
+        await Promise.all(docs.map((doc) => (
+          db.collection(collection).updateOne(
+            // eslint-disable-next-line
+            { _id: doc._id },
+            {
+              $set: { updatedAt: doc.updatedAt },
+              $unset: { updatedOn: null },
+            },
+          )
+        )));
+      }));
+  },
+
+  async down(db) {
+    const collections = ['words', 'examples', 'wordsuggestions', 'examplesuggestions', 'genericwords'];
+    await Promise.all(
+      collections.map(async (collection) => {
+        const docs = await (await db.collection(collection).aggregate(updatedOnRevert)).toArray();
+        await Promise.all(docs.map((doc) => (
+          db.collection(collection).updateOne(
+            // eslint-disable-next-line
+            { _id: doc._id },
+            {
+              $set: { updatedOn: doc.updatedOn },
+              $unset: { updatedAt: null },
+            },
+          )
+        )));
+      }));
+  },
+};

--- a/src/controllers/utils/buildDocs.js
+++ b/src/controllers/utils/buildDocs.js
@@ -72,7 +72,7 @@ export const findWordsWithMatch = async ({
       definitions: 1,
       variations: 1,
       stems: 1,
-      updatedOn: 1,
+      updatedAt: 1,
       pronunciation: 1,
       isStandardIgbo: 1,
       synonyms: 1,

--- a/src/models/Developer.js
+++ b/src/models/Developer.js
@@ -1,5 +1,5 @@
 import mongoose from 'mongoose';
-import { toJSONPlugin, toObjectPlugin, updatedOnHook } from './plugins';
+import { toJSONPlugin, toObjectPlugin } from './plugins';
 
 const { Schema } = mongoose;
 const developerSchema = new Schema({
@@ -8,13 +8,11 @@ const developerSchema = new Schema({
   email: { type: String, default: '', required: true },
   password: { type: String, default: '', required: true },
   usage: {
-    date: { type: Date, default: Date.now() },
+    date: { type: Date, default: new Date().toISOString() },
     count: { type: Number, default: 0 },
   },
-  updatedOn: { type: Date, default: Date.now() },
-}, { toObject: toObjectPlugin });
+}, { toObject: toObjectPlugin, timestamps: true });
 
 toJSONPlugin(developerSchema);
-updatedOnHook(developerSchema);
 
 export default mongoose.model('Developer', developerSchema);

--- a/src/models/Example.js
+++ b/src/models/Example.js
@@ -1,5 +1,5 @@
 import mongoose from 'mongoose';
-import { toJSONPlugin, toObjectPlugin, updatedOnHook } from './plugins';
+import { toJSONPlugin, toObjectPlugin } from './plugins';
 
 const { Schema, Types } = mongoose;
 const exampleSchema = new Schema({
@@ -7,10 +7,8 @@ const exampleSchema = new Schema({
   english: { type: String, default: '' },
   associatedWords: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
   pronunciation: { type: String, default: '' },
-  updatedOn: { type: Date, default: Date.now() },
-}, { toObject: toObjectPlugin });
+}, { toObject: toObjectPlugin, timestamps: true });
 
 toJSONPlugin(exampleSchema);
-updatedOnHook(exampleSchema);
 
 export default mongoose.model('Example', exampleSchema);

--- a/src/models/Word.js
+++ b/src/models/Word.js
@@ -1,6 +1,6 @@
 import mongoose from 'mongoose';
 import { every, has, partial } from 'lodash';
-import { toJSONPlugin, toObjectPlugin, updatedOnHook } from './plugins';
+import { toJSONPlugin, toObjectPlugin } from './plugins';
 import Dialects from '../shared/constants/Dialects';
 import wordClass from '../shared/constants/wordClass';
 
@@ -45,8 +45,7 @@ const wordSchema = new Schema({
   stems: { type: [{ type: String }], default: [] },
   nsibidi: { type: String, default: '' },
   isComplete: { type: Boolean, default: false },
-  updatedOn: { type: Date, default: Date.now() },
-}, { toObject: toObjectPlugin });
+}, { toObject: toObjectPlugin, timestamps: true });
 
 wordSchema.index({
   word: 'text',
@@ -56,7 +55,6 @@ wordSchema.index({
 });
 
 toJSONPlugin(wordSchema);
-updatedOnHook(wordSchema);
 
 const WordModel = mongoose.model('Word', wordSchema);
 WordModel.syncIndexes();

--- a/src/models/plugins/index.js
+++ b/src/models/plugins/index.js
@@ -27,10 +27,3 @@ export const toObjectPlugin = ({
     delete ret.__v;
   },
 });
-
-export const updatedOnHook = (schema) => (
-  schema.pre('save', function () {
-    this.updatedOn = Date.now();
-    return this;
-  })
-);

--- a/tests/shared/constants.js
+++ b/tests/shared/constants.js
@@ -21,9 +21,9 @@ export const WORD_KEYS = [
   'hyponyms',
   'nsibidi',
   'isStandardIgbo',
-  'updatedOn',
+  'updatedAt',
 ];
-export const EXAMPLE_KEYS = ['igbo', 'english', 'associatedWords', 'id', 'pronunciation', 'updatedOn'];
+export const EXAMPLE_KEYS = ['igbo', 'english', 'associatedWords', 'id', 'pronunciation', 'updatedAt', 'createdAt'];
 export const EXCLUDE_KEYS = ['__v', '_id'];
 export const SITE_TITLE = 'The First African Language API';
 export const DOCS_SITE_TITLE = 'Igbo API Documentation';


### PR DESCRIPTION
## Background
The `updatedOn` key was using both Unix and ISO time formats which was causing issues for typed languages. The `updatedOn` field will now be replaced with the `updatedAt` field and it will be using the string ISO format.

Closes #440 