### PR TITLE
feat(word): migrate word schema to support isAccented

### DIFF
--- a/migrations/20220308132126-add-is-accented.js
+++ b/migrations/20220308132126-add-is-accented.js
@@ -1,0 +1,20 @@
+module.exports = {
+  async up(db) {
+    const collections = ['words', 'wordsuggestions'];
+    return collections.map((collection) => (
+      db.collection(collection).updateMany({ isComplete: true }, {
+        $set: { isAccented: true, isComplete: false },
+      })
+    ));
+  },
+
+  async down(db) {
+    const collections = ['words', 'wordsuggestions'];
+    return collections.map((collection) => (
+      db.collection(collection).updateMany({ isAccented: true }, {
+        $unset: { isAccented: null },
+        $set: { isComplete: true },
+      })
+    ));
+  },
+};

--- a/src/controllers/utils/buildDocs.js
+++ b/src/controllers/utils/buildDocs.js
@@ -74,6 +74,7 @@ export const findWordsWithMatch = async ({
       stems: 1,
       updatedAt: 1,
       pronunciation: 1,
+      isAccented: 1,
       isStandardIgbo: 1,
       synonyms: 1,
       antonyms: 1,

--- a/src/models/Word.js
+++ b/src/models/Word.js
@@ -35,6 +35,7 @@ const wordSchema = new Schema({
     default: {},
   },
   pronunciation: { type: String, default: '' },
+  isAccented: { type: Boolean, default: false },
   isStandardIgbo: { type: Boolean, default: false },
   variations: { type: [{ type: String }], default: [] },
   frequency: { type: Number },

--- a/tests/shared/constants.js
+++ b/tests/shared/constants.js
@@ -20,6 +20,7 @@ export const WORD_KEYS = [
   'hypernyms',
   'hyponyms',
   'nsibidi',
+  'isAccented',
   'isStandardIgbo',
   'updatedAt',
 ];


### PR DESCRIPTION
## Background
To better track the words that don't require visible accent marks but should still be labeled as accented, the new `isAccented` field will be applied to Word documents.