### PR TITLE
New Word Search Query Params

### DIFF
--- a/src/controllers/stats.js
+++ b/src/controllers/stats.js
@@ -3,6 +3,7 @@ import Example from '../models/Example';
 import {
   searchForAllWordsWithAudioPronunciations,
   searchForAllWordsWithIsStandardIgbo,
+  searchForAllWordsWithNsibidi,
 } from './utils/queries';
 
 export const getStats = async (_, res, next) => {
@@ -11,11 +12,13 @@ export const getStats = async (_, res, next) => {
     const totalExamples = await Example.countDocuments();
     const totalAudioPronunciations = await Word.find(searchForAllWordsWithAudioPronunciations());
     const totalStandardIgboWords = await Word.find(searchForAllWordsWithIsStandardIgbo());
+    const totalNsibidiWords = await Word.find(searchForAllWordsWithNsibidi());
     return res.send({
       totalWords,
       totalExamples,
       totalAudioPronunciations: totalAudioPronunciations.length,
       totalStandardIgboWords: totalStandardIgboWords.length,
+      totalNsibidiWords: totalNsibidiWords.length,
     });
   } catch (err) {
     return next(err);

--- a/src/controllers/utils/index.js
+++ b/src/controllers/utils/index.js
@@ -141,6 +141,9 @@ export const handleQueries = ({ query = {}, isUsingMainKey }) => {
     strict: strictQuery,
     dialects: dialectsQuery,
     examples: examplesQuery,
+    isStandardIgbo,
+    pronunciation,
+    nsibidi,
   } = query;
   const filter = convertFilterToKeyword(filterQuery);
   const searchWord = removePrefix(keyword || filter || '');
@@ -163,5 +166,10 @@ export const handleQueries = ({ query = {}, isUsingMainKey }) => {
     dialects,
     examples,
     isUsingMainKey,
+    wordFields: {
+      isStandardIgbo,
+      pronunciation,
+      nsibidi,
+    },
   };
 };

--- a/src/controllers/utils/queries.js
+++ b/src/controllers/utils/queries.js
@@ -29,3 +29,6 @@ export const searchForAllWordsWithAudioPronunciations = () => ({
 export const searchForAllWordsWithIsStandardIgbo = () => ({
   isStandardIgbo: true,
 });
+export const searchForAllWordsWithNsibidi = () => ({
+  nsibidi: { $ne: '' },
+});

--- a/src/controllers/utils/queries.js
+++ b/src/controllers/utils/queries.js
@@ -1,16 +1,14 @@
 import createRegExp from '../../shared/utils/createRegExp';
 
-const fullTextSearchQuery = (keyword, isUsingMainKey) => (isUsingMainKey && !keyword
-  ? { word: { $regex: /./ } }
-  : { $text: { $search: keyword } }
+const fullTextSearchQuery = ({ keyword, isUsingMainKey, requiredAttributes }) => (isUsingMainKey && !keyword
+  ? { word: { $regex: /./ }, ...requiredAttributes }
+  : { $text: { $search: keyword }, ...requiredAttributes }
 );
 
-/* Searching for words that match the keyword and also the wordClass */
-export const searchIgboTextWithWordClass = ({ searchWord, wordClass, isUsingMainKey }) => (isUsingMainKey && !searchWord
-  ? { $and: [{ word: { $regex: /./ } }, { wordClass }] }
-  : { $and: [{ $text: { $search: searchWord } }, { wordClass }] }
-);
-const definitionsQuery = (regex) => ({ definitions: { $in: [regex] } });
+const definitionsQuery = ({ regex, requiredAttributes }) => ({
+  definitions: { $in: [regex] },
+  ...requiredAttributes,
+});
 
 /* Regex match query used to later to defined the Content-Range response header */
 export const searchExamplesRegexQuery = (regex) => ({ $or: [{ igbo: regex }, { english: regex }] });

--- a/src/pages/components/Statistics/Statistics.js
+++ b/src/pages/components/Statistics/Statistics.js
@@ -8,6 +8,7 @@ const Statistics = ({
   totalExamples,
   totalAudioPronunciations,
   totalStandardIgboWords,
+  totalNsibidiWords,
   contributors,
   stars,
 }) => {
@@ -26,7 +27,7 @@ const Statistics = ({
           value={totalStandardIgboWords}
           header={t('Standard Igbo words').replace('{{number}}', totalStandardIgboWords)}
         />
-        {/* <Stat value={10} header={t('Words in Nsịbịdị').replace('{{number}}', 10)} /> */}
+        <Stat value={totalNsibidiWords} header={t('Words in Nsịbịdị').replace('{{number}}', totalNsibidiWords)} />
       </div>
       <div className="flex flex-row justify-center items-center flex-wrap w-full lg:w-9/12">
         {contributors ? (
@@ -63,6 +64,7 @@ Statistics.propTypes = {
   totalExamples: PropTypes.number,
   totalAudioPronunciations: PropTypes.number,
   totalStandardIgboWords: PropTypes.number,
+  totalNsibidiWords: PropTypes.number,
   contributors: PropTypes.arrayOf(PropTypes.shape({})),
   stars: PropTypes.number,
 };
@@ -72,6 +74,7 @@ Statistics.defaultProps = {
   totalExamples: 0,
   totalAudioPronunciations: 0,
   totalStandardIgboWords: 0,
+  totalNsibidiWords: 0,
   contributors: [],
   stars: 0,
 };

--- a/swagger.json
+++ b/swagger.json
@@ -134,6 +134,27 @@
             "in": "query",
             "required": false,
             "type": "boolean"
+          },
+          {
+            "name": "isStandardIgbo",
+            "description": "Returns words that are marked as Standard Igbo",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "pronunciation",
+            "description": "Returns words that have audio pronunciations",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "nsibidi",
+            "description": "Returns words that have Nsịbịdị equivalents",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "responses": {

--- a/tests/api-mongo.test.js
+++ b/tests/api-mongo.test.js
@@ -47,6 +47,7 @@ describe('MongoDB Words', () => {
           done();
         });
     });
+
     it('should fail populate mongodb with incorrect variations', (done) => {
       const word = {
         word: 'word',
@@ -483,7 +484,6 @@ describe('MongoDB Words', () => {
         });
     });
 
-    // TODO: Remove lingering sorting direction logic
     it('should return a descending sorted list of words with sort query', (done) => {
       const key = 'word';
       const direction = SortingDirections.DESCENDING;
@@ -585,6 +585,93 @@ describe('MongoDB Words', () => {
           });
           done();
         });
+    });
+
+    it('should return a word marked as isStandardIgbo', (done) => {
+      const word = {
+        word: 'standardIgboWord',
+        wordClass: 'NNC',
+        definitions: ['first definition', 'second definition'],
+        dialects: {},
+        examples: [new ObjectId(), new ObjectId()],
+        isStandardIgbo: true,
+        stems: [],
+      };
+      const validWord = new Word(word);
+      validWord.save().then(() => {
+        getWords({ keyword: word.word, isStandardIgbo: true })
+          .end((_, res) => {
+            expect(res.status).to.equal(200);
+            expect(res.body).to.have.lengthOf.at.least(1);
+            forEach(res.body, (wordRes) => {
+              expect(wordRes.isStandardIgbo).to.be.equal(true);
+            });
+            getWords({ keyword: word.word, pronunciation: true })
+              .end((error, noRes) => {
+                expect(noRes.status).to.equal(200);
+                expect(noRes.body).to.have.lengthOf(0);
+                done();
+              });
+          });
+      });
+    });
+
+    it('should return a word marked with nsibidi', (done) => {
+      const word = {
+        word: 'nsibidi',
+        wordClass: 'NNC',
+        definitions: ['first definition', 'second definition'],
+        dialects: {},
+        examples: [new ObjectId(), new ObjectId()],
+        nsibidi: 'nsibidi',
+        stems: [],
+      };
+      const validWord = new Word(word);
+      validWord.save().then(() => {
+        getWords({ keyword: word.word, nsibidi: true })
+          .end((_, res) => {
+            expect(res.status).to.equal(200);
+            expect(res.body).to.have.lengthOf.at.least(1);
+            forEach(res.body, (wordRes) => {
+              expect(wordRes.nsibidi).to.not.equal(undefined);
+            });
+            getWords({ keyword: word.word, isStandardIgbo: true })
+              .end((error, noRes) => {
+                expect(noRes.status).to.equal(200);
+                expect(noRes.body).to.have.lengthOf(0);
+                done();
+              });
+          });
+      });
+    });
+
+    it('should return a word marked with nsibidi', (done) => {
+      const word = {
+        word: 'pronunciation',
+        wordClass: 'NNC',
+        definitions: ['first definition', 'second definition'],
+        dialects: {},
+        examples: [new ObjectId(), new ObjectId()],
+        pronunciation: 'audio-pronunciation',
+        stems: [],
+      };
+      const validWord = new Word(word);
+      validWord.save().then(() => {
+        getWords({ keyword: word.word, pronunciation: true })
+          .end((_, res) => {
+            expect(res.status).to.equal(200);
+            expect(res.body).to.have.lengthOf.at.least(1);
+            forEach(res.body, (wordRes) => {
+              expect(wordRes.pronunciation.length).to.be.at.least(10);
+            });
+            getWords({ keyword: word.word, nsibidi: true })
+              .end((error, noRes) => {
+                expect(noRes.status).to.equal(200);
+                expect(noRes.body).to.have.lengthOf(0);
+                done();
+              });
+          });
+      });
     });
   });
 });


### PR DESCRIPTION
## Background
To enable filtering through word results, the Igbo API now supports filtering word results through three new queries: `isStandardIgbo`, `nsibidi`, and `pronunciation`.

### Homepage with Nsịbịdị statistics
The Igbo API homepage now shows Nsịbịdị word count.

<img width="1300" alt="Screen Shot 2022-03-26 at 3 59 53 PM" src="https://user-images.githubusercontent.com/16169291/160255696-80c9a256-8cbe-49c2-80ed-adc9f1bb67e4.png">

